### PR TITLE
fix: 重置鈕固定 min-width 避免 armed 時擠歪按鈕 (#22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-pomodoro-capybara",
   "productName": "Capybara Pomodoro",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A simple pomodoro timer with capybara",
   "main": "dist/main.js",
   "repository": "git@github.com:Shiou-Ju/electron-pomodoro-capybara.git",

--- a/src/renderer/components/styled.tsx
+++ b/src/renderer/components/styled.tsx
@@ -55,6 +55,7 @@ export const Button = styled(motion.button, {
   background: ${({ theme, armed }) => (armed ? theme.warning : theme.accent)};
   color: ${({ theme, armed }) => (armed ? theme.warningText : theme.buttonText)};
   border: none;
+  min-width: 7.5rem;
   padding: 0.6rem 1.2rem;
   border-radius: 6px;
   font-size: 0.9rem;


### PR DESCRIPTION
## 問題
重置鈕二次確認時文字由「重置」變「確認重置？」，但 `Button` 無固定寬度、靠 padding 撐開 → 變寬。容器 `ButtonGroup` 為 `flex; justify-content:center`，重置鈕變寬使整列重新置中，「開始/暫停」鈕被擠到旁邊。

## 修法（版本 A，使用者選定）
`src/renderer/components/styled.tsx` 的 `Button` 加 `min-width: 7.5rem;`。該元件同時被開始/暫停與重置使用，兩鈕等寬對稱置中；armed 文字變長不再撐寬按鈕、整列不再位移。純 CSS，計時邏輯不動。

## 驗收
- 點擊重置進入 armed 狀態，「開始」鈕位置不位移。
- `npx tsc --noEmit` 通過。
- 取捨：先前以可點擊 HTML demo 比較 A/B/C 三版，選定最穩定、對稱的 A 版。

Closes #22