### PR TITLE
feat: 新增計時器模式（分鐘倒數 + streak）

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,15 @@ pnpm format         # prettier 格式化 src 下所有檔案
 pnpm package        # mac + win + linux
 pnpm package:mac    # 僅 macOS（dmg）
 
+pnpm test           # 單元測試（Vitest，跑一次）
+pnpm test:watch     # 單元測試 watch 模式
+
 npx tsc --noEmit    # 型別檢查（無專用 typecheck script）
-npx eslint src      # lint（eslint.config.mjs，整合 prettier）
 ```
 
-無測試框架。
+**Lint 現況**：`eslint.config.mjs` 仍是舊式（eslintrc）格式，在 ESLint 9 flat config 下實際不生效（`npx eslint src` 會回報全檔 ignored）。目前品質把關靠 `npx tsc --noEmit`（型別）＋ `pnpm format`（prettier）。
+
+**測試**：用 **Vitest**。純函式測試與其原始檔同放於 `src/renderer/utils/`（如 `streak.ts` / `streak.test.ts`）。`tsconfig.json` 以 `exclude: ["**/*.test.ts"]`、electron-builder `build.files` 以 `!dist/**/*.test.*` 確保測試檔不進 `dist`／打包。React hook 邏輯偏好抽成純函式再測（避免 DOM 環境）。
 
 ## 建置架構（兩段式編譯，關鍵）
 
@@ -43,8 +47,8 @@ npx eslint src      # lint（eslint.config.mjs，整合 prettier）
 三個進程層，透過 contextBridge + IPC 溝通（`contextIsolation: true`、`nodeIntegration: false`）：
 
 1. **Main（`src/main.ts`）**：建立 `BrowserWindow`（`resizable: false`）、處理系統通知、註冊全域快捷鍵。
-2. **Preload（`src/preload.ts`）**：用 `contextBridge.exposeInMainWorld('electronAPI', ...)` 暴露 `getVersion` / `sendNotification` / `dismissNotification` / `onToggleLayout` 給 renderer。型別定義在 `src/renderer/types/electron.d.ts`。
-3. **Renderer（`src/renderer/`）**：React app，核心狀態在 `usePomodoro` hook。
+2. **Preload（`src/preload.ts`）**：用 `contextBridge.exposeInMainWorld('electronAPI', ...)` 暴露 `getVersion` / `sendNotification` / `dismissNotification` / `onToggleLayout` / `onToggleMode` 給 renderer。型別定義在 `src/renderer/types/electron.d.ts`。
+3. **Renderer（`src/renderer/`）**：React app。`App.tsx` 持有 `appMode`（`'pomodoro' | 'timer'`，localStorage `capybara-app-mode`），同時掛載 `usePomodoro` 與 `useTimer` 兩個 hook，依 `appMode` 決定渲染哪一套並接線；計數由 `useStreak` 統一管理。倒數計時邏輯（rAF + `Date.now()` delta）抽在共用的 `useCountdownTick`，番茄鐘與計時器都用它。
 
 ### 番茄鐘狀態機（`src/renderer/hooks/usePomodoro.ts`）
 
@@ -62,11 +66,24 @@ npx eslint src      # lint（eslint.config.mjs，整合 prettier）
 - main（`src/main.ts`）用一個 `Set<Notification>` 記住目前在畫面上的通知；每個通知 `on('close')` 時自清。renderer 按 `c` 或 `Esc` → `dismissNotification()` → `dismiss-notification` IPC → main 把 Set 內所有通知 `close()`。
 - 純加法，**不更動兩處 `sendNotification` 的送出邏輯**（見下方「通知邏輯重複」）。
 
+### 計時器模式（`src/renderer/hooks/useTimer.ts`）
+
+- 有別於番茄鐘循環，計時器是**純倒數**：只支援分鐘（內部仍秒級倒數，用 `useCountdownTick`）。
+- 設定狀態（未開始）顯示步進器 `− 分 +`；`+/-`（鍵盤 `+`/`=`/`-`）±1 分，`gi`（vim 風格 g 前綴 chord，見 `useKeyboardControls`）進入直接輸入。範圍 `MIN_MINUTES`(1)–`MAX_MINUTES`(9999)。
+- `Cmd+T` 經 electron-localshortcut 註冊在視窗（`src/main.ts`，與 `Cmd+L` 同模式），`webContents.send('toggle-mode')` 通知 renderer 切 `appMode`；切換時暫停兩邊計時。
+- 強調色：計時器用暖琥珀，定義在 `src/renderer/themes/colors.ts`（`AccentKey = PomodoroMode | 'timer'`，亮色另有加深版）。
+- 結束時發系統通知但**不**自動進下一階段；圖片沿用 `capybara-focus.png`。
+
+### streak（`src/renderer/hooks/useStreak.ts` + `utils/streak.ts`）
+
+- 番茄鐘與計時器**共用**單一累積值，存 localStorage `capybara-streak`。番茄完成 +1、計時結束 +`分鐘/25`（25 分 = 1.00）。
+- 計算為純函式集中在 `src/renderer/utils/streak.ts`（`round2` / `minutesToStreak` / `addStreak` / `clampMinutes`），有對應單元測試。
+- 兩模式底部統一顯示「完成的番茄鐘: X.XX」（小數 2 位）。
+
 ## 已知的待整理處（與 main 分支現況相關）
 
-- **通知邏輯重複**：`App.tsx` 的 `useEffect` 與 `usePomodoro.ts` 內各有一份 `sendNotification`，兩者都在 `timeLeft === 0` 時觸發（當前分支 `fix/notification-not-last` 正在處理此類問題）。改通知行為時注意兩處。
+- **通知邏輯重複**：`App.tsx` 的 `useEffect` 與 `usePomodoro.ts` 內各有一份番茄鐘 `sendNotification`，兩者都在 `timeLeft === 0` 時觸發。改通知行為時注意兩處。
 - `usePomodoro.ts` 的 `getNextState` 被標註「not used」但實際上有被 effect 呼叫——修改前先確認實際引用。
-- `src/preload.ts` import 了 `ipcRenderer` 與 main.ts import 了 `globalShortcut` 但部分未使用。
 
 ## 平台慣例
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ npx tsc --noEmit    # 型別檢查（無專用 typecheck script）
 
 ## 已知的待整理處（與 main 分支現況相關）
 
-- **通知邏輯重複**：`App.tsx` 的 `useEffect` 與 `usePomodoro.ts` 內各有一份番茄鐘 `sendNotification`，兩者都在 `timeLeft === 0` 時觸發。改通知行為時注意兩處。
+- 番茄鐘倒數結束通知統一由 `App.tsx` 的 effect 送出；`usePomodoro.ts` 原本那份條件 `timeLeft===0 && !isRunning` 為永不成立的死碼，已移除（改通知行為只需改 `App.tsx` 一處）。
 - `usePomodoro.ts` 的 `getNextState` 被標註「not used」但實際上有被 effect 呼叫——修改前先確認實際引用。
 
 ## 平台慣例

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
 # electron-pomodoro-capybara
 
+卡皮巴拉番茄鐘 — Electron + React 桌面番茄鐘 / 計時器。
 
-- 標準番茄鐘計時（25分鐘）
-- 短休息時間（5分鐘）
-- 長休息時間（10分鐘，每4個番茄鐘後）
+## 功能
+
+### 番茄鐘模式
+
+- 標準番茄鐘計時（25 分鐘）
+- 短休息（5 分鐘）
+- 長休息（10 分鐘，每 4 個番茄鐘後）
+
+### 計時器模式
+
+- 純倒數計時，只支援分鐘
+- 設定時間：`+` / `−` 每次 ±1 分，或 `gi` 直接輸入分鐘數（範圍 1–9999）
+- 時間到發系統通知，不自動進入下一階段
+
+### 共用
+
+- **streak**：番茄鐘與計時器共用累積值（番茄完成 +1、計時 +分鐘/25），底部顯示「完成的番茄鐘: X.XX」，記錄於本機並跨啟動保留
 - 暗黑模式（右上角切換，跟隨系統、記住偏好）
-- 鍵盤操作：`p` 開始/暫停、`r` 重置（二次確認）、`n` 跳下一階段、`d` 切換暗色、`c`/`Esc` 關閉通知、`hjkl`/方向鍵移動焦點
+
+### 快捷鍵
+
+- `p` 開始 / 暫停、`r` 重置（二次確認）、`n` 跳下一階段（番茄鐘）
+- `+` / `=` 加 1 分、`-` 減 1 分、`gi` 輸入分鐘（計時器設定時）
+- `d` 切換暗色、`c` / `Esc` 關閉通知
+- `hjkl` / 方向鍵移動焦點
+- `Cmd+T` 切換番茄鐘 / 計時器、`Cmd+L` 切換直式 / 橫式佈局
 
 ## 開發
 
@@ -15,37 +37,14 @@
 pnpm install        # 安裝相依（electron binary 自動 build）
 pnpm dev            # 開發模式（watch + 啟動 electron，計時為秒級方便測試）
 pnpm build          # 生產建置
+pnpm test           # 單元測試（Vitest）
 pnpm package:mac    # 打包 macOS dmg，輸出至 release/
 ```
 
-## fix
-1. src/preload.ts 同時導入了 ipcRenderer（雖然未使用）與暴露 sendNotification API，使用原生 Notification API 實作簡單通知，符合需求。
-2. 現在的視窗調整
-   1. 可能調成 1200 比較好看
-   2. 在 src/main.ts 中修改了視窗尺寸（從 800x600 改成 600x1000），這是預期中的 UI 調整。
-3. dev 環境的通知是 electron 的，生產環境的不確定
-4. 現在 app name ，但是希望是中文，然後再 spotlight 搜尋的時候，可以搜尋到 英文
+## 安裝（macOS）
 
-## refactor
-1. 修改背景為粉紅色
+DMG **未做程式碼簽章**，首次開啟會被 Gatekeeper 擋下。請對 app 按右鍵 →「打開」→ 確認，或到「系統設定 → 隱私權與安全性」放行。
 
+## App 名稱與 Spotlight
 
-
-# app name issue
-但是我看另外一款 app 
-
-他在資料夾是`番茄鐘`
-
-但是我在 spotlight 打 tomato 找得到他？ 
-
-## 解釋
-在 macOS 平台上，應用程序的名稱在不同情況下可能會有所不同。具體如下：
-
-* 在 Finder 中，應用程序的名稱是根據 `productName` 定義的，即「卡皮巴拉番茄鐘」。
-* 在 Spotlight 搜尋時，系統會使用以下關鍵字進行匹配：
-  + capybara（來自 InfoPlist.strings）
-  + pomodoro（來自 InfoPlist.strings）
-  + 卡皮巴拉（來自 productName）
-  + 番茄鐘（來自 productName）
-
-
+在 macOS 上，Finder 顯示的是 `productName`「Capybara Pomodoro」；Spotlight 可用 `capybara`、`pomodoro`（來自 `InfoPlist.strings`）與中文「卡皮巴拉」「番茄鐘」搜尋到。

--- a/docs/timer-mode-preview.html
+++ b/docs/timer-mode-preview.html
@@ -1,0 +1,395 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>卡皮巴拉 — 計時器模式設計稿（分鐘倒數 + / − 設定）</title>
+    <style>
+      :root {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 2rem;
+        background: #4b5563;
+        color: #f3f4f6;
+      }
+      h1 {
+        margin: 0 0 0.25rem;
+        font-size: 1.6rem;
+      }
+      .intro {
+        margin: 0 0 1.5rem;
+        opacity: 0.9;
+        max-width: 72ch;
+        line-height: 1.6;
+      }
+      h2.section {
+        font-size: 1.05rem;
+        margin: 1.75rem 0 0.9rem;
+        padding-bottom: 0.4rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: flex-start;
+      }
+
+      /* 全尺寸卡片，模擬實際 app（portrait 風格），沿用 preview-2 的卡片結構 */
+      .card {
+        width: 260px;
+        border-radius: 14px;
+        padding: 1.5rem 1rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--surface);
+      }
+      .card .mode-tag {
+        font-size: 0.78rem;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        color: var(--accent);
+        opacity: 0.95;
+      }
+      .card .title {
+        font-size: 1.35rem;
+        font-weight: 600;
+        margin: 0;
+        color: var(--text);
+      }
+      .card .capybara {
+        width: 96px;
+        height: 96px;
+        object-fit: contain;
+        border-radius: 12px;
+        background: var(--surface);
+      }
+      .card .timer {
+        font-size: 2.6rem;
+        font-weight: bold;
+        color: var(--accent);
+        letter-spacing: 1px;
+      }
+
+      /* 設定列：− [分鐘] + 的步進器（僅在「未開始」時顯示） */
+      .stepper {
+        display: flex;
+        align-items: center;
+        gap: 0.85rem;
+      }
+      .stepper .display {
+        font-size: 2.6rem;
+        font-weight: bold;
+        color: var(--accent);
+        letter-spacing: 1px;
+        min-width: 4.5rem;
+        text-align: center;
+      }
+      .stepper .unit {
+        font-size: 1rem;
+        font-weight: 500;
+        opacity: 0.7;
+        margin-left: 0.15rem;
+      }
+      .step-btn {
+        width: 2.6rem;
+        height: 2.6rem;
+        border-radius: 50%;
+        border: none;
+        cursor: pointer;
+        font-size: 1.5rem;
+        line-height: 1;
+        background: var(--surface);
+        color: var(--accent);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.15s;
+      }
+      .step-btn:hover {
+        background: var(--accent);
+        color: var(--btn-text);
+      }
+      .step-btn.focused {
+        outline: 3px solid var(--focus-ring);
+        outline-offset: 2px;
+      }
+
+      .card .buttons {
+        display: flex;
+        gap: 0.75rem;
+      }
+      .card button.action {
+        border: none;
+        cursor: pointer;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        font-size: 0.9rem;
+        background: var(--accent);
+        color: var(--btn-text);
+        transition: background 0.15s;
+      }
+      .card button.action:hover {
+        background: var(--accent-hover);
+      }
+      .card button.action.focused {
+        outline: 3px solid var(--focus-ring);
+        outline-offset: 2px;
+      }
+      .card .completed {
+        font-size: 0.85rem;
+        margin: 0;
+        color: var(--text);
+        opacity: 0.85;
+      }
+      .state-label {
+        font-size: 0.8rem;
+        opacity: 0.8;
+        margin: 0.5rem 0 0;
+        font-style: italic;
+      }
+      .tokens {
+        font-size: 0.72rem;
+        opacity: 0.75;
+        margin-top: 0.55rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        line-height: 1.5;
+        max-width: 260px;
+      }
+      .note {
+        font-size: 0.85rem;
+        opacity: 0.9;
+        margin: 0.6rem 0 0;
+        max-width: 72ch;
+        line-height: 1.6;
+      }
+      ul.spec {
+        max-width: 72ch;
+        line-height: 1.65;
+        font-size: 0.9rem;
+      }
+      code {
+        background: rgba(0, 0, 0, 0.25);
+        padding: 0.05rem 0.35rem;
+        border-radius: 4px;
+        font-size: 0.85em;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>計時器模式 · 設計稿（分鐘倒數，+ / − 設定）</h1>
+    <p class="intro">
+      延續
+      <code>dark-mode-preview-2.html</code>
+      的精神：<strong>石板炭灰</strong>底色 +
+      模式專屬強調色。計時器模式採用一組<strong>暖琥珀色</strong>，與專注（紅）/
+      短休（綠）/ 長休（藍）區隔。只支援<strong>分鐘</strong>，未開始時用
+      <code>−</code> / <code>+</code>
+      圓鈕加減分鐘數；開始後步進器收起、改顯示倒數。色值與初始/上下限皆可微調，確認後寫進
+      <code>src/renderer/themes/colors.ts</code>。
+    </p>
+
+    <h2 class="section">暗色 · 計時器模式（石板底 #1a1d23 · 琥珀強調）</h2>
+    <div class="row">
+      <!-- 暗 · 設定中（未開始）：顯示 − 25 + 步進器 -->
+      <div>
+        <div
+          class="card"
+          style="
+            --bg: #1a1d23;
+            --surface: #262b33;
+            --text: #e4e6eb;
+            --accent: #e0a44a;
+            --accent-hover: #eab866;
+            --btn-text: #1f1404;
+            --focus-ring: #eab866;
+          "
+        >
+          <span class="mode-tag">計時器 timer</span>
+          <p class="title">卡皮巴拉計時器</p>
+          <img
+            class="capybara"
+            src="../public/assets/capybara-focus.png"
+            alt="timer"
+          />
+          <div class="stepper">
+            <button class="step-btn">−</button>
+            <span class="display">25<span class="unit">分</span></span>
+            <button class="step-btn focused">+</button>
+          </div>
+          <div class="buttons">
+            <button class="action">開始</button>
+            <button class="action">重置</button>
+          </div>
+          <p class="state-label">狀態 A：設定中（未開始）— 顯示 − / + 步進器</p>
+        </div>
+        <div class="tokens">
+          accent #e0a44a · hover #eab866 · btn #1f1404<br />
+          + / − 鈕：surface 底 + accent 字，focus 時填滿
+        </div>
+      </div>
+
+      <!-- 暗 · 倒數中：步進器收起，顯示時間 -->
+      <div>
+        <div
+          class="card"
+          style="
+            --bg: #1a1d23;
+            --surface: #262b33;
+            --text: #e4e6eb;
+            --accent: #e0a44a;
+            --accent-hover: #eab866;
+            --btn-text: #1f1404;
+            --focus-ring: #eab866;
+          "
+        >
+          <span class="mode-tag">計時器 timer</span>
+          <p class="title">卡皮巴拉計時器</p>
+          <img
+            class="capybara"
+            src="../public/assets/capybara-focus.png"
+            alt="timer"
+          />
+          <div class="timer">18:42</div>
+          <div class="buttons">
+            <button class="action focused">暫停</button>
+            <button class="action">重置</button>
+          </div>
+          <p class="state-label">狀態 B：倒數中 — 步進器收起，僅顯示時間</p>
+        </div>
+        <div class="tokens">
+          倒數顯示沿用既有 <code>Timer</code> 樣式（3.2rem / accent 色）<br />
+          開始 → 文字變「暫停」，與番茄鐘一致
+        </div>
+      </div>
+    </div>
+
+    <h2 class="section">亮色 · 計時器模式（白底 · 同組琥珀強調）</h2>
+    <div class="row">
+      <!-- 亮 · 設定中 -->
+      <div>
+        <div
+          class="card"
+          style="
+            --bg: #ffffff;
+            --surface: #f0f2f5;
+            --text: #2c3e50;
+            --accent: #d6912f;
+            --accent-hover: #c07f22;
+            --btn-text: #ffffff;
+            --focus-ring: #c07f22;
+          "
+        >
+          <span class="mode-tag">計時器 timer</span>
+          <p class="title">卡皮巴拉計時器</p>
+          <img
+            class="capybara"
+            src="../public/assets/capybara-focus.png"
+            alt="timer"
+          />
+          <div class="stepper">
+            <button class="step-btn">−</button>
+            <span class="display">25<span class="unit">分</span></span>
+            <button class="step-btn focused">+</button>
+          </div>
+          <div class="buttons">
+            <button class="action">開始</button>
+            <button class="action">重置</button>
+          </div>
+          <p class="state-label">狀態 A：設定中（未開始）</p>
+        </div>
+        <div class="tokens">
+          accent #d6912f · hover #c07f22（亮色略加深以保對比）
+        </div>
+      </div>
+
+      <!-- 亮 · 倒數中 -->
+      <div>
+        <div
+          class="card"
+          style="
+            --bg: #ffffff;
+            --surface: #f0f2f5;
+            --text: #2c3e50;
+            --accent: #d6912f;
+            --accent-hover: #c07f22;
+            --btn-text: #ffffff;
+            --focus-ring: #c07f22;
+          "
+        >
+          <span class="mode-tag">計時器 timer</span>
+          <p class="title">卡皮巴拉計時器</p>
+          <img
+            class="capybara"
+            src="../public/assets/capybara-focus.png"
+            alt="timer"
+          />
+          <div class="timer">18:42</div>
+          <div class="buttons">
+            <button class="action focused">暫停</button>
+            <button class="action">重置</button>
+          </div>
+          <p class="state-label">狀態 B：倒數中</p>
+        </div>
+        <div class="tokens">倒數中與番茄鐘排版一致，僅強調色不同</div>
+      </div>
+    </div>
+
+    <h2 class="section">互動規格（提案，待你確認）</h2>
+    <ul class="spec">
+      <li>
+        <strong>單位</strong>：只支援分鐘；內部仍以秒倒數（沿用
+        <code>usePomodoro</code> 的 rAF + Date.now delta）。
+      </li>
+      <li>
+        <strong>+ / − 設定</strong>：每次 ±1 分鐘（可改 ±5）。範圍建議
+        <code>1–90 分</code>，初始 <code>25 分</code>。
+      </li>
+      <li>
+        <strong>顯示切換</strong>：未開始 = 步進器（− 25
+        +）；按「開始」後步進器收起、顯示 <code>MM:SS</code> 倒數。
+      </li>
+      <li>
+        <strong>鍵盤</strong>：沿用 vim 風格焦點移動（h/l、方向鍵）；新增
+        <code>+</code> / <code>=</code> 加分鐘、<code>-</code> 減分鐘。<code
+          >p</code
+        >
+        開始/暫停、<code>r</code> 重置（二次確認）不變。
+      </li>
+      <li>
+        <strong>結束行為</strong>：時間到發系統通知（沿用現有
+        <code>sendNotification</code> + <code>c</code>/<code>Esc</code>
+        關閉）；不自動進入下一階段（與番茄鐘循環不同）。
+      </li>
+      <li>
+        <strong>streak（issue #9 原案）</strong>：時間到後把
+        <code>分鐘 / 25</code> 累加到 streak，取小數 2 位（例 12.5 分 =
+        +0.5）。<em>待確認是否本次一起做。</em>
+      </li>
+      <li>
+        <strong>圖片</strong>：先沿用
+        <code>capybara-focus.png</code>；若要專屬圖再加
+        <code>capybara-timer.png</code>。
+      </li>
+      <li>
+        <strong>模式切換</strong>：可比照
+        <code>Cmd+L</code> 佈局切換，加一個番茄鐘 ⇄ 計時器的切換鍵（待定）。
+      </li>
+    </ul>
+
+    <p class="note">
+      決策點：(1) 步進間距 ±1 還是 ±5？(2) 分鐘上下限（建議 1–90）？(3)
+      琥珀色採用或微調？ (4) streak 規則（#9 原案）本次是否一起做？(5) 番茄鐘 ⇄
+      計時器要用什麼方式切換？ 確認後我再進實作。
+    </p>
+  </body>
+</html>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,19 +3,19 @@ export default {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: './tsconfig.json',
-    sourceType: 'module'
+    sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'prettier'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended'
+    'plugin:prettier/recommended',
   ],
   env: {
     node: true,
-    es6: true
+    es6: true,
   },
   rules: {
-    'prettier/prettier': 'error'
-  }
+    'prettier/prettier': 'error',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "package:mac": "pnpm build && electron-builder build --mac",
     "package:win": "pnpm build && electron-builder build --win",
     "package:linux": "pnpm build && electron-builder build --linux",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,html,css,scss,md}\"",
     "make-icons": "electron-icon-maker --input=./public/assets/capybara-longBreak.png --output=./build"
   },
@@ -55,6 +57,7 @@
     "prettier": "^3.5.0",
     "ts-loader": "^9.5.2",
     "typescript": "^5.7.3",
+    "vitest": "^3.2.6",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1"
   },
@@ -62,6 +65,7 @@
     "appId": "com.electron.capybara-pomodoro",
     "files": [
       "dist/**/*",
+      "!dist/**/*.test.*",
       "package.json",
       "public/**/*"
     ],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,html,css,scss,md}\"",
-    "make-icons": "electron-icon-maker --input=./public/assets/capybara-longBreak.png --output=./build"
+    "make-icons": "electron-icon-maker --input=./public/assets/capybara-longBreak.png --output=./build",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json,css,scss,md,html}": "prettier --write"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
@@ -53,6 +57,8 @@
     "eslint": "^9.20.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.3",
+    "husky": "^9.1.7",
+    "lint-staged": "^17.0.8",
     "nodemon": "^3.1.9",
     "prettier": "^3.5.0",
     "ts-loader": "^9.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-pomodoro-capybara",
   "productName": "Capybara Pomodoro",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A simple pomodoro timer with capybara",
   "main": "dist/main.js",
   "repository": "git@github.com:Shiou-Ju/electron-pomodoro-capybara.git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-pomodoro-capybara",
   "productName": "Capybara Pomodoro",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A simple pomodoro timer with capybara",
   "main": "dist/main.js",
   "repository": "git@github.com:Shiou-Ju/electron-pomodoro-capybara.git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-pomodoro-capybara",
   "productName": "Capybara Pomodoro",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A simple pomodoro timer with capybara",
   "main": "dist/main.js",
   "repository": "git@github.com:Shiou-Ju/electron-pomodoro-capybara.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,12 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.2.3
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^17.0.8
+        version: 17.0.8
       nodemon:
         specifier: ^3.1.9
         version: 3.1.14
@@ -86,7 +92,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
       webpack:
         specifier: ^5.97.1
         version: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
@@ -1096,6 +1102,10 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@2.1.1:
     resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
@@ -1372,6 +1382,10 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -1379,6 +1393,10 @@ packages:
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cliui@3.2.0:
     resolution: {integrity: sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==}
@@ -1636,6 +1654,9 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1660,6 +1681,10 @@ packages:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -1788,6 +1813,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -1993,6 +2021,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2153,6 +2185,11 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   icon-gen@2.0.0:
     resolution: {integrity: sha512-Asj0rWMoFDY3AHLsZdx8UgHX7AIh/9u5ZTXYWJYH+2n8HqHQr655ATdoa1yQLidmm2fnTYlob+Rm4zzrjWr5Bw==}
     engines: {node: '>= 8'}
@@ -2249,6 +2286,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-function@1.0.2:
     resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
@@ -2501,6 +2542,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@17.0.8:
+    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+    engines: {node: '>=22.22.1'}
+    hasBin: true
+
+  listr2@10.2.1:
+    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+    engines: {node: '>=22.13.0'}
+
   load-bmfont@1.4.2:
     resolution: {integrity: sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==}
 
@@ -2544,6 +2594,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -2614,6 +2668,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -2788,6 +2846,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3152,6 +3214,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -3159,6 +3225,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -3272,6 +3341,14 @@ packages:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -3337,6 +3414,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-similarity@1.1.0:
     resolution: {integrity: sha512-x+Ul/yDujT1PIgcKuP6NP71VgoB+NKY8ccoH2nrfnFcYH2gtoRE0XLpUaHBIx4ZdpIWnYzWAsjp2QO+ZRC3Fjg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -3352,6 +3433,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -3495,6 +3584,10 @@ packages:
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -3779,6 +3872,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@2.1.0:
     resolution: {integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==}
     engines: {node: '>=0.10.0'}
@@ -3790,6 +3887,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -3829,6 +3930,11 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4785,13 +4891,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -4971,6 +5077,10 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@2.1.1: {}
 
@@ -5325,6 +5435,10 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-spinners@2.9.2: {}
 
   cli-truncate@2.1.0:
@@ -5332,6 +5446,11 @@ snapshots:
       slice-ansi: 3.0.0
       string-width: 4.2.3
     optional: true
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
 
   cliui@3.2.0:
     dependencies:
@@ -5650,6 +5769,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -5671,6 +5792,8 @@ snapshots:
   env-paths@2.2.1: {}
 
   envinfo@7.21.0: {}
+
+  environment@1.1.0: {}
 
   err-code@2.0.3: {}
 
@@ -5828,6 +5951,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -6028,6 +6153,8 @@ snapshots:
   get-caller-file@1.0.3: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -6247,6 +6374,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  husky@9.1.7: {}
+
   icon-gen@2.0.0:
     dependencies:
       del: 3.0.0
@@ -6329,6 +6458,10 @@ snapshots:
       number-is-nan: 1.0.1
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-function@1.0.2: {}
 
@@ -6538,6 +6671,23 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@17.0.8:
+    dependencies:
+      listr2: 10.2.1
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.2.4
+    optionalDependencies:
+      yaml: 2.9.0
+
+  listr2@10.2.1:
+    dependencies:
+      cli-truncate: 5.2.0
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 10.0.0
+
   load-bmfont@1.4.2:
     dependencies:
       buffer-equal: 0.0.1
@@ -6587,6 +6737,14 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   loupe@3.2.1: {}
 
@@ -6655,6 +6813,8 @@ snapshots:
   mime@2.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   mimic-response@1.0.1: {}
 
@@ -6828,6 +6988,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   optionator@0.9.4:
     dependencies:
@@ -7180,9 +7344,16 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@2.7.1:
     dependencies:
@@ -7313,6 +7484,16 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
     optional: true
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@7.0.0:
@@ -7380,6 +7561,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-argv@0.3.2: {}
+
   string-similarity@1.1.0:
     dependencies:
       lodash: 4.18.1
@@ -7400,6 +7583,17 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
@@ -7519,6 +7713,8 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -7643,13 +7839,13 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-node@3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+  vite-node@3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7664,7 +7860,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+  vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7677,12 +7873,13 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
       terser: 5.48.0
+      yaml: 2.9.0
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -7700,8 +7897,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
-      vite-node: 3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -7818,6 +8015,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
+
   wrap-ansi@2.1.0:
     dependencies:
       string-width: 1.0.2
@@ -7833,6 +8036,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
@@ -7864,6 +8073,9 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,12 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
       webpack:
         specifier: ^5.97.1
-        version: 5.107.2(webpack-cli@6.0.1)
+        version: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.1
         version: 6.0.1(webpack@5.107.2)
@@ -229,6 +232,162 @@ packages:
 
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -513,6 +672,131 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -532,8 +816,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -637,6 +927,35 @@ packages:
   '@typescript-eslint/visitor-keys@8.60.1':
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -860,6 +1179,10 @@ packages:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -965,6 +1288,10 @@ packages:
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacache@16.1.3:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -1002,6 +1329,10 @@ packages:
   centra@2.7.0:
     resolution: {integrity: sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -1009,6 +1340,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1194,6 +1529,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1336,6 +1675,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -1352,6 +1694,11 @@ packages:
 
   es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1435,6 +1782,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1445,6 +1795,10 @@ packages:
 
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -1986,6 +2340,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -2071,6 +2428,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2118,6 +2545,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -2132,6 +2562,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
@@ -2270,6 +2703,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -2463,6 +2901,13 @@ packages:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -2540,6 +2985,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2725,6 +3174,11 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2796,6 +3250,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2826,6 +3283,10 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -2866,9 +3327,15 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-similarity@1.1.0:
     resolution: {integrity: sha512-x+Ul/yDujT1PIgcKuP6NP71VgoB+NKY8ccoH2nrfnFcYH2gtoRE0XLpUaHBIx4ZdpIWnYzWAsjp2QO+ZRC3Fjg==}
@@ -2911,6 +3378,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -3017,12 +3487,30 @@ packages:
   timm@1.7.1:
     resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3152,6 +3640,79 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': 22.13.1
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': 22.13.1
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -3201,6 +3762,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -3509,6 +4075,84 @@ snapshots:
   '@emotion/utils@1.4.2': {}
 
   '@emotion/weak-memoize@0.4.0': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
@@ -3891,6 +4535,81 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
@@ -3908,9 +4627,16 @@ snapshots:
       '@types/node': 22.13.1
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -4051,6 +4777,48 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -4129,17 +4897,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@xmldom/xmldom@0.9.10': {}
@@ -4332,6 +5100,8 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   astral-regex@2.0.0:
     optional: true
 
@@ -4448,6 +5218,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  cac@6.7.14: {}
+
   cacache@16.1.3:
     dependencies:
       '@npmcli/fs': 2.1.2
@@ -4504,6 +5276,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -4516,6 +5296,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -4641,7 +5423,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
 
   core-util-is@1.0.2: {}
 
@@ -4698,6 +5480,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -4898,6 +5682,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
@@ -4915,6 +5701,35 @@ snapshots:
     optional: true
 
   es6-promise@4.2.8: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -5008,11 +5823,17 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   events@3.3.0: {}
 
   exif-parser@0.1.12: {}
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -5587,6 +6408,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -5663,6 +6486,56 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
+
   lines-and-columns@1.2.4: {}
 
   load-bmfont@1.4.2:
@@ -5715,6 +6588,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  loupe@3.2.1: {}
+
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
@@ -5724,6 +6599,10 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -5857,6 +6736,8 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
 
@@ -6058,6 +6939,10 @@ snapshots:
 
   path-type@6.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   pe-library@0.4.1: {}
 
   pend@1.2.0: {}
@@ -6123,6 +7008,12 @@ snapshots:
   pngjs-nozlib@1.0.0: {}
 
   pngjs@3.4.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -6311,6 +7202,37 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6372,6 +7294,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6403,6 +7327,8 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -6448,7 +7374,11 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@3.10.0: {}
 
   string-similarity@1.1.0:
     dependencies:
@@ -6497,6 +7427,10 @@ snapshots:
       is-utf8: 0.2.1
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   stylis@4.2.0: {}
 
@@ -6559,13 +7493,15 @@ snapshots:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
-  terser-webpack-plugin@5.6.1(webpack@5.107.2):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.107.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
+    optionalDependencies:
+      lightningcss: 1.32.0
 
   terser@5.48.0:
     dependencies:
@@ -6578,12 +7514,22 @@ snapshots:
 
   timm@1.7.1: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -6620,7 +7566,7 @@ snapshots:
       semver: 7.8.2
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
 
   tslib@2.8.1: {}
 
@@ -6697,6 +7643,83 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
+  vite-node@3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.13.1
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.48.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+      vite-node: 3.2.4(@types/node@22.13.1)(lightningcss@1.32.0)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 22.13.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -6720,7 +7743,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
   webpack-merge@6.0.1:
@@ -6731,7 +7754,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2(webpack-cli@6.0.1):
+  webpack@5.107.2(lightningcss@1.32.0)(webpack-cli@6.0.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -6753,7 +7776,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(webpack@5.107.2)
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.107.2)
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     optionalDependencies:
@@ -6781,6 +7804,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
-import { app, BrowserWindow, Notification, ipcMain, globalShortcut } from 'electron';
+import { app, BrowserWindow, Notification, ipcMain } from 'electron';
 import * as path from 'path';
 import { layouts } from './renderer/themes/layouts';
 import electronLocalshortcut from 'electron-localshortcut';
-
 
 // 記住目前還在畫面上的通知，供「c / Esc 一鍵關閉」使用
 const activeNotifications = new Set<Notification>();
@@ -17,10 +16,12 @@ ipcMain.on('show-notification', (_, { title, body }) => {
       icon: path.resolve(__dirname, '../public/assets/capybara-longBreak.png'),
       timeoutType: 'default',
       urgency: 'normal',
-      actions: [{
-        type: 'button',
-        text: '確定'
-      }]
+      actions: [
+        {
+          type: 'button',
+          text: '確定',
+        },
+      ],
     });
 
     activeNotifications.add(notification);
@@ -43,7 +44,7 @@ let currentLayout: 'portrait' | 'landscape' = 'landscape';
 function createWindow(layoutType: 'portrait' | 'landscape' = 'landscape') {
   currentLayout = layoutType;
   const { width, height } = layouts[currentLayout].window;
-  
+
   const mainWindow = new BrowserWindow({
     width,
     height,
@@ -51,18 +52,20 @@ function createWindow(layoutType: 'portrait' | 'landscape' = 'landscape') {
       nodeIntegration: false,
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
-      backgroundThrottling: false
+      backgroundThrottling: false,
     },
     backgroundColor: '#FFFFFF',
     show: false,
-    resizable: false  // 防止用戶調整視窗大小
+    resizable: false, // 防止用戶調整視窗大小
   });
 
   const isMac = process.platform === 'darwin';
-  
+
   if (isMac) {
-    app.setName('Capybara Pomodoro');  // 使用英文名稱
-    app.dock.setIcon(path.resolve(__dirname, '../public/assets/capybara-longBreak.png'));
+    app.setName('Capybara Pomodoro'); // 使用英文名稱
+    app.dock.setIcon(
+      path.resolve(__dirname, '../public/assets/capybara-longBreak.png'),
+    );
   }
 
   // 開發環境使用
@@ -72,7 +75,12 @@ function createWindow(layoutType: 'portrait' | 'landscape' = 'landscape') {
     // mainWindow.webContents.openDevTools();
   } else {
     // 使用 app.getAppPath() 來確保在打包後能正確找到檔案
-    const indexPath = path.join(app.getAppPath(), 'dist', 'renderer', 'index.html');
+    const indexPath = path.join(
+      app.getAppPath(),
+      'dist',
+      'renderer',
+      'index.html',
+    );
     mainWindow.loadFile(indexPath);
   }
 
@@ -90,13 +98,18 @@ function createWindow(layoutType: 'portrait' | 'landscape' = 'landscape') {
   electronLocalshortcut.register(mainWindow, 'CommandOrControl+L', () => {
     const newLayout = currentLayout === 'portrait' ? 'landscape' : 'portrait';
     const { width, height } = layouts[newLayout].window;
-    
+
     mainWindow.setSize(width, height);
     mainWindow.center();
-    
+
     currentLayout = newLayout;
-    
+
     mainWindow.webContents.send('toggle-layout');
+  });
+
+  // 切換番茄鐘 ⇄ 計時器模式（與佈局切換同模式，純通知 renderer）
+  electronLocalshortcut.register(mainWindow, 'CommandOrControl+T', () => {
+    mainWindow.webContents.send('toggle-mode');
   });
 
   // 清理快捷鍵
@@ -110,7 +123,7 @@ app.whenReady().then(() => {
     // 設定 macOS 的通知權限
     app.setActivationPolicy('regular');
   }
-  
+
   createWindow();
 
   app.on('activate', () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -10,10 +10,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   dismissNotification: () => {
     ipcRenderer.send('dismiss-notification');
   },
+  // 回傳 unsubscribe，供 renderer effect cleanup，避免重複註冊累積 listener
   onToggleLayout: (callback: () => void) => {
-    ipcRenderer.on('toggle-layout', () => callback());
+    const handler = () => callback();
+    ipcRenderer.on('toggle-layout', handler);
+    return () => ipcRenderer.removeListener('toggle-layout', handler);
   },
   onToggleMode: (callback: () => void) => {
-    ipcRenderer.on('toggle-mode', () => callback());
+    const handler = () => callback();
+    ipcRenderer.on('toggle-mode', handler);
+    return () => ipcRenderer.removeListener('toggle-mode', handler);
   },
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -12,5 +12,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   onToggleLayout: (callback: () => void) => {
     ipcRenderer.on('toggle-layout', () => callback());
-  }
+  },
+  onToggleMode: (callback: () => void) => {
+    ipcRenderer.on('toggle-mode', () => callback());
+  },
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -99,10 +99,11 @@ const App: React.FC = () => {
   }, [isTimer, pomodoro.state.timeLeft, pomodoro.state.mode]);
 
   useEffect(() => {
-    // 監聽來自 main process 的切換信號
-    window.electronAPI.onToggleLayout(() => {
+    // 監聽來自 main process 的切換信號；回傳 unsubscribe 供 cleanup（避免重複註冊）
+    const unsubscribe = window.electronAPI.onToggleLayout(() => {
       setLayout((prev) => (prev === 'portrait' ? 'landscape' : 'portrait'));
     });
+    return unsubscribe;
   }, []);
 
   // 進入分鐘輸入時自動 focus 並全選
@@ -162,12 +163,17 @@ const App: React.FC = () => {
     setAppMode((prev) => (prev === 'timer' ? 'pomodoro' : 'timer'));
   }, [timer, pomodoro, disarmReset]);
 
-  // 監聽 Cmd+T 切換模式
+  // 以 ref 穩定 toggleMode，讓監聽 effect 只註冊一次（toggleMode 每 render 會重建）
+  const toggleModeRef = useRef(toggleMode);
+  toggleModeRef.current = toggleMode;
+
+  // 監聽 Cmd+T 切換模式（deps []，配合 cleanup 只註冊一次）
   useEffect(() => {
-    window.electronAPI.onToggleMode(() => {
-      toggleMode();
+    const unsubscribe = window.electronAPI.onToggleMode(() => {
+      toggleModeRef.current();
     });
-  }, [toggleMode]);
+    return unsubscribe;
+  }, []);
 
   const dismissNotification = useCallback(() => {
     window.electronAPI.dismissNotification();

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { usePomodoro } from './hooks/usePomodoro';
+import { useTimer } from './hooks/useTimer';
 import { useKeyboardControls } from './hooks/useKeyboardControls';
 import { buildTheme } from './themes/colors';
 import {
@@ -15,15 +16,25 @@ import {
   Timer,
   Button,
   ToggleButton,
+  ModeToggleButton,
   CapybaraImage,
   ContentWrapper,
   ButtonGroup,
   CompletedText,
+  Stepper,
+  StepButton,
+  MinutesDisplay,
+  MinutesUnit,
+  MinutesInput,
+  StreakText,
 } from './components/styled';
 import { AnimatePresence } from 'framer-motion';
 
 const THEME_STORAGE_KEY = 'capybara-theme';
+const APP_MODE_STORAGE_KEY = 'capybara-app-mode';
 const RESET_CONFIRM_TIMEOUT = 3000;
+
+type AppMode = 'pomodoro' | 'timer';
 
 // 初始主題：優先讀 localStorage，無值則跟隨系統深淺色（同步讀取以避免閃白）
 const getInitialDarkMode = (): boolean => {
@@ -33,22 +44,34 @@ const getInitialDarkMode = (): boolean => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
 
+const getInitialAppMode = (): AppMode =>
+  localStorage.getItem(APP_MODE_STORAGE_KEY) === 'timer' ? 'timer' : 'pomodoro';
+
 const App: React.FC = () => {
-  const { state, startTimer, pauseTimer, resetTimer, skipToNext } =
-    usePomodoro();
+  const pomodoro = usePomodoro();
+  const timer = useTimer();
+
+  const [appMode, setAppMode] = useState<AppMode>(getInitialAppMode);
   const [layout, setLayout] = useState<'portrait' | 'landscape'>('landscape');
   const [resetArmed, setResetArmed] = useState(false);
   const [isDark, setIsDark] = useState<boolean>(getInitialDarkMode);
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+
+  const isTimer = appMode === 'timer';
 
   const playButtonRef = useRef<HTMLButtonElement>(null);
   const resetButtonRef = useRef<HTMLButtonElement>(null);
+  const modeButtonRef = useRef<HTMLButtonElement>(null);
   const darkButtonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // theme 同時依「明暗」與「目前模式」計算（強調色隨模式變化）
+  // theme 同時依「明暗」與「目前模式」計算：計時器用琥珀，否則跟番茄鐘模式
+  const accentKey = isTimer ? 'timer' : pomodoro.state.mode;
   const theme = useMemo(
-    () => buildTheme(isDark, state.mode),
-    [isDark, state.mode],
+    () => buildTheme(isDark, accentKey),
+    [isDark, accentKey],
   );
 
   // 開窗自動 focus 啟動鈕：一進來按 Enter/Space 即可開始（免滑鼠）
@@ -56,18 +79,23 @@ const App: React.FC = () => {
     playButtonRef.current?.focus();
   }, []);
 
-  // 持久化主題偏好
+  // 持久化主題與模式偏好
   useEffect(() => {
     localStorage.setItem(THEME_STORAGE_KEY, isDark ? 'dark' : 'light');
   }, [isDark]);
 
   useEffect(() => {
-    if (state.timeLeft === 0) {
-      const message = state.mode === 'focus' ? '該休息一下嘍！' : '繼續努力～';
+    localStorage.setItem(APP_MODE_STORAGE_KEY, appMode);
+  }, [appMode]);
 
+  // 番茄鐘倒數結束通知（沿用既有行為；計時器的通知在 useTimer 內處理）
+  useEffect(() => {
+    if (!isTimer && pomodoro.state.timeLeft === 0) {
+      const message =
+        pomodoro.state.mode === 'focus' ? '該休息一下嘍！' : '繼續努力～';
       window.electronAPI.sendNotification('卡皮巴拉番茄鐘', message);
     }
-  }, [state.timeLeft, state.mode]);
+  }, [isTimer, pomodoro.state.timeLeft, pomodoro.state.mode]);
 
   useEffect(() => {
     // 監聽來自 main process 的切換信號
@@ -76,13 +104,27 @@ const App: React.FC = () => {
     });
   }, []);
 
-  const togglePlay = useCallback(() => {
-    if (state.isRunning) {
-      pauseTimer();
-    } else {
-      startTimer();
+  // 進入分鐘輸入時自動 focus 並全選
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
     }
-  }, [state.isRunning, pauseTimer, startTimer]);
+  }, [editing]);
+
+  const togglePlay = useCallback(() => {
+    const running = isTimer ? timer.state.isRunning : pomodoro.state.isRunning;
+    if (running) {
+      isTimer ? timer.pauseTimer() : pomodoro.pauseTimer();
+    } else {
+      isTimer ? timer.startTimer() : pomodoro.startTimer();
+    }
+  }, [isTimer, timer, pomodoro]);
+
+  const resetActive = useCallback(() => {
+    if (isTimer) timer.resetTimer();
+    else pomodoro.resetTimer();
+  }, [isTimer, timer, pomodoro]);
 
   const disarmReset = useCallback(() => {
     if (resetTimeoutRef.current) {
@@ -96,7 +138,7 @@ const App: React.FC = () => {
   const requestReset = useCallback(() => {
     if (resetArmed) {
       disarmReset();
-      resetTimer();
+      resetActive();
     } else {
       setResetArmed(true);
       resetTimeoutRef.current = setTimeout(() => {
@@ -104,15 +146,50 @@ const App: React.FC = () => {
         setResetArmed(false);
       }, RESET_CONFIRM_TIMEOUT);
     }
-  }, [resetArmed, disarmReset, resetTimer]);
+  }, [resetArmed, disarmReset, resetActive]);
 
   const toggleDark = useCallback(() => {
     setIsDark((prev) => !prev);
   }, []);
 
+  // 切換番茄鐘 ⇄ 計時器：暫停兩邊計時、解除重置確認與輸入狀態
+  const toggleMode = useCallback(() => {
+    timer.pauseTimer();
+    pomodoro.pauseTimer();
+    disarmReset();
+    setEditing(false);
+    setAppMode((prev) => (prev === 'timer' ? 'pomodoro' : 'timer'));
+  }, [timer, pomodoro, disarmReset]);
+
+  // 監聽 Cmd+T 切換模式
+  useEffect(() => {
+    window.electronAPI.onToggleMode(() => {
+      toggleMode();
+    });
+  }, [toggleMode]);
+
   const dismissNotification = useCallback(() => {
     window.electronAPI.dismissNotification();
   }, []);
+
+  // gi：進入分鐘直接輸入（僅計時器設定狀態）
+  const enterInput = useCallback(() => {
+    if (!isTimer || timer.state.hasStarted) return;
+    setInputValue(String(timer.state.minutes));
+    setEditing(true);
+  }, [isTimer, timer.state.hasStarted, timer.state.minutes]);
+
+  const commitInput = useCallback(() => {
+    const n = parseInt(inputValue, 10);
+    if (!Number.isNaN(n)) timer.setMinutes(n);
+    setEditing(false);
+  }, [inputValue, timer]);
+
+  const cancelInput = useCallback(() => {
+    setEditing(false);
+  }, []);
+
+  const noop = useCallback(() => {}, []);
 
   // 解除 timeout，避免 unmount 後觸發 setState
   useEffect(
@@ -123,18 +200,21 @@ const App: React.FC = () => {
   );
 
   const focusRefs = useMemo(
-    () => [playButtonRef, resetButtonRef, darkButtonRef],
+    () => [playButtonRef, resetButtonRef, modeButtonRef, darkButtonRef],
     [],
   );
 
   useKeyboardControls({
     onTogglePlay: togglePlay,
     onRequestReset: requestReset,
-    onSkipNext: skipToNext,
+    onSkipNext: isTimer ? noop : pomodoro.skipToNext,
     onToggleDark: toggleDark,
     onCancel: disarmReset,
     onDismissNotification: dismissNotification,
     focusRefs,
+    onIncrement: isTimer ? timer.increment : undefined,
+    onDecrement: isTimer ? timer.decrement : undefined,
+    onEnterInput: isTimer ? enterInput : undefined,
   });
 
   const formatTime = (seconds: number): string => {
@@ -144,6 +224,11 @@ const App: React.FC = () => {
       .toString()
       .padStart(2, '0')}`;
   };
+
+  const isRunning = isTimer ? timer.state.isRunning : pomodoro.state.isRunning;
+  const imageMode = isTimer ? 'focus' : pomodoro.state.mode;
+  const imageKey = isTimer ? 'timer' : pomodoro.state.mode;
+  const title = isTimer ? '卡皮巴拉計時器' : '卡皮巴拉番茄鐘';
 
   return (
     <ThemeProvider theme={theme}>
@@ -159,6 +244,17 @@ const App: React.FC = () => {
         `}
       />
       <Container layout={layout}>
+        <ModeToggleButton
+          ref={modeButtonRef}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={toggleMode}
+          title="切換番茄鐘 / 計時器 (Cmd+T)"
+          aria-label="切換番茄鐘或計時器模式"
+        >
+          {isTimer ? '⏱' : '🍅'}
+        </ModeToggleButton>
+
         <ToggleButton
           ref={darkButtonRef}
           whileHover={{ scale: 1.1 }}
@@ -170,13 +266,13 @@ const App: React.FC = () => {
           {isDark ? '☀' : '☾'}
         </ToggleButton>
 
-        <Title layout={layout}>卡皮巴拉番茄鐘</Title>
+        <Title layout={layout}>{title}</Title>
 
         <ContentWrapper>
           <AnimatePresence mode="wait">
             <CapybaraImage
-              key={state.mode}
-              src={`assets/capybara-${state.mode}.png`}
+              key={imageKey}
+              src={`assets/capybara-${imageMode}.png`}
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
               exit={{ scale: 0 }}
@@ -184,7 +280,55 @@ const App: React.FC = () => {
             />
           </AnimatePresence>
 
-          <Timer>{formatTime(state.timeLeft)}</Timer>
+          {isTimer && !timer.state.hasStarted ? (
+            editing ? (
+              <MinutesInput
+                ref={inputRef}
+                type="text"
+                inputMode="numeric"
+                maxLength={4}
+                value={inputValue}
+                onChange={(e) =>
+                  setInputValue(e.target.value.replace(/\D/g, '').slice(0, 4))
+                }
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitInput();
+                  else if (e.key === 'Escape') cancelInput();
+                }}
+                onBlur={commitInput}
+                aria-label="輸入分鐘數"
+              />
+            ) : (
+              <Stepper>
+                <StepButton
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.9 }}
+                  onClick={timer.decrement}
+                  aria-label="減一分鐘"
+                >
+                  −
+                </StepButton>
+                <MinutesDisplay>
+                  {timer.state.minutes}
+                  <MinutesUnit>分</MinutesUnit>
+                </MinutesDisplay>
+                <StepButton
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.9 }}
+                  onClick={timer.increment}
+                  aria-label="加一分鐘"
+                >
+                  +
+                </StepButton>
+              </Stepper>
+            )
+          ) : (
+            <Timer>
+              {formatTime(
+                isTimer ? timer.state.timeLeft : pomodoro.state.timeLeft,
+              )}
+            </Timer>
+          )}
 
           <ButtonGroup>
             <Button
@@ -193,7 +337,7 @@ const App: React.FC = () => {
               whileTap={{ scale: 0.9 }}
               onClick={togglePlay}
             >
-              {state.isRunning ? '暫停' : '開始'}
+              {isRunning ? '暫停' : '開始'}
             </Button>
 
             <Button
@@ -208,9 +352,15 @@ const App: React.FC = () => {
             </Button>
           </ButtonGroup>
 
-          <CompletedText>
-            完成的番茄鐘: {state.completedPomodoros}
-          </CompletedText>
+          {isTimer ? (
+            <StreakText>
+              累積 streak: {timer.state.streak.toFixed(2)}
+            </StreakText>
+          ) : (
+            <CompletedText>
+              完成的番茄鐘: {pomodoro.state.completedPomodoros}
+            </CompletedText>
+          )}
         </ContentWrapper>
       </Container>
     </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -353,7 +353,7 @@ const App: React.FC = () => {
             </Button>
           </ButtonGroup>
 
-          <StreakText>累積 streak: {streak.toFixed(2)}</StreakText>
+          <StreakText>完成的番茄鐘: {streak.toFixed(2)}</StreakText>
         </ContentWrapper>
       </Container>
     </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -66,6 +66,7 @@ const App: React.FC = () => {
   const modeButtonRef = useRef<HTMLButtonElement>(null);
   const darkButtonRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false); // 分鐘輸入是否被 Esc 取消
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // theme 同時依「明暗」與「目前模式」計算：計時器用琥珀，否則跟番茄鐘模式
@@ -182,17 +183,25 @@ const App: React.FC = () => {
   // gi：進入分鐘直接輸入（僅計時器設定狀態）
   const enterInput = useCallback(() => {
     if (!isTimer || timer.state.hasStarted) return;
+    cancelledRef.current = false;
     setInputValue(String(timer.state.minutes));
     setEditing(true);
   }, [isTimer, timer.state.hasStarted, timer.state.minutes]);
 
   const commitInput = useCallback(() => {
+    // Esc 取消後，unmount 觸發的 onBlur 不應再存檔
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      setEditing(false);
+      return;
+    }
     const n = parseInt(inputValue, 10);
     if (!Number.isNaN(n)) timer.setMinutes(n);
     setEditing(false);
   }, [inputValue, timer]);
 
   const cancelInput = useCallback(() => {
+    cancelledRef.current = true;
     setEditing(false);
   }, []);
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,6 +8,7 @@ import React, {
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { usePomodoro } from './hooks/usePomodoro';
 import { useTimer } from './hooks/useTimer';
+import { useStreak } from './hooks/useStreak';
 import { useKeyboardControls } from './hooks/useKeyboardControls';
 import { buildTheme } from './themes/colors';
 import {
@@ -20,7 +21,6 @@ import {
   CapybaraImage,
   ContentWrapper,
   ButtonGroup,
-  CompletedText,
   Stepper,
   StepButton,
   MinutesDisplay,
@@ -48,8 +48,9 @@ const getInitialAppMode = (): AppMode =>
   localStorage.getItem(APP_MODE_STORAGE_KEY) === 'timer' ? 'timer' : 'pomodoro';
 
 const App: React.FC = () => {
-  const pomodoro = usePomodoro();
-  const timer = useTimer();
+  const { streak, addStreak } = useStreak();
+  const pomodoro = usePomodoro(undefined, () => addStreak(1));
+  const timer = useTimer((gained) => addStreak(gained));
 
   const [appMode, setAppMode] = useState<AppMode>(getInitialAppMode);
   const [layout, setLayout] = useState<'portrait' | 'landscape'>('landscape');
@@ -226,8 +227,8 @@ const App: React.FC = () => {
   };
 
   const isRunning = isTimer ? timer.state.isRunning : pomodoro.state.isRunning;
+  // key 用實際圖片：番茄(focus) ⇄ 計時 同圖不重播動畫，切換才會即時無延遲
   const imageMode = isTimer ? 'focus' : pomodoro.state.mode;
-  const imageKey = isTimer ? 'timer' : pomodoro.state.mode;
   const title = isTimer ? '卡皮巴拉計時器' : '卡皮巴拉番茄鐘';
 
   return (
@@ -252,7 +253,7 @@ const App: React.FC = () => {
           title="切換番茄鐘 / 計時器 (Cmd+T)"
           aria-label="切換番茄鐘或計時器模式"
         >
-          {isTimer ? '⏱' : '🍅'}
+          {isTimer ? '計時' : '番茄'}
         </ModeToggleButton>
 
         <ToggleButton
@@ -263,7 +264,7 @@ const App: React.FC = () => {
           title="切換深色模式 (d)"
           aria-label="切換深色模式"
         >
-          {isDark ? '☀' : '☾'}
+          {isDark ? '暗' : '亮'}
         </ToggleButton>
 
         <Title layout={layout}>{title}</Title>
@@ -271,7 +272,7 @@ const App: React.FC = () => {
         <ContentWrapper>
           <AnimatePresence mode="wait">
             <CapybaraImage
-              key={imageKey}
+              key={imageMode}
               src={`assets/capybara-${imageMode}.png`}
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
@@ -352,15 +353,7 @@ const App: React.FC = () => {
             </Button>
           </ButtonGroup>
 
-          {isTimer ? (
-            <StreakText>
-              累積 streak: {timer.state.streak.toFixed(2)}
-            </StreakText>
-          ) : (
-            <CompletedText>
-              完成的番茄鐘: {pomodoro.state.completedPomodoros}
-            </CompletedText>
-          )}
+          <StreakText>累積 streak: {streak.toFixed(2)}</StreakText>
         </ContentWrapper>
       </Container>
     </ThemeProvider>

--- a/src/renderer/components/styled.tsx
+++ b/src/renderer/components/styled.tsx
@@ -74,21 +74,22 @@ export const Button = styled(motion.button, {
   }
 `;
 
-// 暗色 / 亮色切換鈕：右上角低調 icon 鈕
+// 暗色 / 亮色切換鈕：右上角低調文字鈕
 export const ToggleButton = styled(motion.button)`
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  width: 2rem;
   height: 2rem;
+  min-width: 2rem;
+  padding: 0 0.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
   background: transparent;
   color: ${({ theme }) => theme.textPrimary};
   border: none;
-  border-radius: 50%;
-  font-size: 1.1rem;
+  border-radius: 1rem;
+  font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
 
@@ -198,7 +199,7 @@ export const MinutesInput = styled.input`
 export const ModeToggleButton = styled(motion.button)`
   position: absolute;
   top: 0.75rem;
-  right: 3rem;
+  right: 3.75rem;
   height: 2rem;
   min-width: 2rem;
   padding: 0 0.5rem;
@@ -209,7 +210,7 @@ export const ModeToggleButton = styled(motion.button)`
   color: ${({ theme }) => theme.textPrimary};
   border: none;
   border-radius: 1rem;
-  font-size: 1.1rem;
+  font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
 

--- a/src/renderer/components/styled.tsx
+++ b/src/renderer/components/styled.tsx
@@ -53,7 +53,8 @@ export const Button = styled(motion.button, {
   shouldForwardProp: (prop) => prop !== 'armed',
 })<{ armed?: boolean }>`
   background: ${({ theme, armed }) => (armed ? theme.warning : theme.accent)};
-  color: ${({ theme, armed }) => (armed ? theme.warningText : theme.buttonText)};
+  color: ${({ theme, armed }) =>
+    armed ? theme.warningText : theme.buttonText};
   border: none;
   min-width: 7.5rem;
   padding: 0.6rem 1.2rem;
@@ -116,6 +117,113 @@ export const CapybaraImage = styled(motion.img)`
 `;
 
 export const CompletedText = styled.p`
+  font-size: 1rem;
+  color: ${({ theme }) => theme.textPrimary};
+  margin: 0;
+`;
+
+// 計時器設定列：− [分鐘] +
+export const Stepper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-bottom: 1.5rem;
+`;
+
+export const StepButton = styled(motion.button)`
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  font-size: 1.6rem;
+  line-height: 1;
+  background: ${({ theme }) => theme.surface};
+  color: ${({ theme }) => theme.accent};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: ${({ theme }) => theme.accent};
+    color: ${({ theme }) => theme.buttonText};
+  }
+
+  &:focus-visible {
+    outline: 3px solid ${({ theme }) => theme.focusRing};
+    outline-offset: 2px;
+  }
+`;
+
+export const MinutesDisplay = styled.div`
+  font-size: 3.2rem;
+  font-weight: bold;
+  color: ${({ theme }) => theme.accent};
+  min-width: 5rem;
+  text-align: center;
+`;
+
+export const MinutesUnit = styled.span`
+  font-size: 1rem;
+  font-weight: 500;
+  opacity: 0.7;
+  margin-left: 0.2rem;
+`;
+
+// gi 直接輸入分鐘用
+export const MinutesInput = styled.input`
+  font-size: 3.2rem;
+  font-weight: bold;
+  color: ${({ theme }) => theme.accent};
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid ${({ theme }) => theme.accent};
+  width: 5rem;
+  text-align: center;
+  padding: 0;
+
+  &:focus {
+    outline: none;
+  }
+
+  /* 隱藏 number spinner（保險，實際用 text + inputMode=numeric） */
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;
+
+// 模式切換鈕（番茄鐘 ⇄ 計時器）：放在暗色鈕左側
+export const ModeToggleButton = styled(motion.button)`
+  position: absolute;
+  top: 0.75rem;
+  right: 3rem;
+  height: 2rem;
+  min-width: 2rem;
+  padding: 0 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: ${({ theme }) => theme.textPrimary};
+  border: none;
+  border-radius: 1rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ theme }) => theme.surface};
+  }
+
+  &:focus-visible {
+    outline: 3px solid ${({ theme }) => theme.focusRing};
+    outline-offset: 2px;
+  }
+`;
+
+export const StreakText = styled.p`
   font-size: 1rem;
   color: ${({ theme }) => theme.textPrimary};
   margin: 0;

--- a/src/renderer/config/pomodoro.config.ts
+++ b/src/renderer/config/pomodoro.config.ts
@@ -14,4 +14,4 @@ export const prodSettings = {
 
 export const getPomodoroSettings = () => {
   return process.env.NODE_ENV === 'production' ? prodSettings : devSettings;
-}; 
+};

--- a/src/renderer/hooks/useCountdownTick.ts
+++ b/src/renderer/hooks/useCountdownTick.ts
@@ -8,10 +8,14 @@ import { useEffect, useRef } from 'react';
  */
 export const useCountdownTick = (
   isRunning: boolean,
+  timeLeft: number,
   onTick: (deltaSeconds: number) => void,
 ): void => {
   const onTickRef = useRef(onTick);
   onTickRef.current = onTick;
+  // 以 ref 取得最新 timeLeft，供迴圈在歸零時停止排幀（防呆，見下）
+  const timeLeftRef = useRef(timeLeft);
+  timeLeftRef.current = timeLeft;
 
   useEffect(() => {
     if (!isRunning) return;
@@ -25,10 +29,14 @@ export const useCountdownTick = (
 
       if (deltaTime >= 1) {
         onTickRef.current(deltaTime);
-        lastTime = currentTime;
+        // 保留不足一秒的餘量，避免每秒重新等滿一整秒造成系統性偏慢
+        lastTime += deltaTime * 1000;
       }
 
-      animationFrameId = requestAnimationFrame(update);
+      // 防呆：時間歸零即停止排下一幀，不依賴消費端一定把 isRunning 設 false
+      if (timeLeftRef.current > 0) {
+        animationFrameId = requestAnimationFrame(update);
+      }
     };
 
     animationFrameId = requestAnimationFrame(update);

--- a/src/renderer/hooks/useCountdownTick.ts
+++ b/src/renderer/hooks/useCountdownTick.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * 共用倒數計時器：以 requestAnimationFrame + Date.now() 計算經過的整秒數，
+ * 每滿 1 秒呼叫一次 onTick(deltaSeconds)。不持有時間狀態，由呼叫端自行扣減。
+ *
+ * 用 ref 保存 onTick，避免每次 callback 改變就重啟 rAF 迴圈。
+ */
+export const useCountdownTick = (
+  isRunning: boolean,
+  onTick: (deltaSeconds: number) => void,
+): void => {
+  const onTickRef = useRef(onTick);
+  onTickRef.current = onTick;
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    let animationFrameId: number;
+    let lastTime = Date.now();
+
+    const update = () => {
+      const currentTime = Date.now();
+      const deltaTime = Math.floor((currentTime - lastTime) / 1000);
+
+      if (deltaTime >= 1) {
+        onTickRef.current(deltaTime);
+        lastTime = currentTime;
+      }
+
+      animationFrameId = requestAnimationFrame(update);
+    };
+
+    animationFrameId = requestAnimationFrame(update);
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [isRunning]);
+};

--- a/src/renderer/hooks/useKeyboardControls.ts
+++ b/src/renderer/hooks/useKeyboardControls.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 type FocusRef = React.RefObject<HTMLElement | null>;
 
@@ -10,12 +10,19 @@ interface KeyboardControlsOptions {
   onCancel: () => void; // Esc：取消（例如解除重置確認）
   onDismissNotification: () => void; // c / Esc：關掉畫面上的通知
   focusRefs: FocusRef[]; // h/l、方向鍵在這些控制間移動焦點
+  onIncrement?: () => void; // + / =：計時器加 1 分
+  onDecrement?: () => void; // -：計時器減 1 分
+  onEnterInput?: () => void; // gi：進入分鐘直接輸入
 }
+
+// g 前綴 chord 的有效時間窗（gi）
+const CHORD_TIMEOUT = 500;
 
 /**
  * 在 window 上掛一個 keydown listener，提供 vim 風格的鍵盤操作。
  * 焦點在 app 視窗內時生效；保留帶修飾鍵的快捷鍵（如 Cmd+L 切換佈局）。
  * Enter / Space 啟動目前 focus 的按鈕，沿用原生 button 行為，這裡不攔截。
+ * 計時器模式額外支援 + / − 調整分鐘、gi 進入直接輸入。
  */
 export const useKeyboardControls = ({
   onTogglePlay,
@@ -25,8 +32,23 @@ export const useKeyboardControls = ({
   onCancel,
   onDismissNotification,
   focusRefs,
+  onIncrement,
+  onDecrement,
+  onEnterInput,
 }: KeyboardControlsOptions) => {
+  // 記住「g」是否在等待後續鍵（chord），與其逾時計時器
+  const pendingGRef = useRef(false);
+  const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
+    const clearChord = () => {
+      pendingGRef.current = false;
+      if (chordTimerRef.current) {
+        clearTimeout(chordTimerRef.current);
+        chordTimerRef.current = null;
+      }
+    };
+
     const moveFocus = (dir: 1 | -1) => {
       const els = focusRefs
         .map((ref) => ref.current)
@@ -40,12 +62,34 @@ export const useKeyboardControls = ({
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // 焦點在輸入框時，交給輸入框自己處理（Enter/Esc 等），不攔截 vim 鍵
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement) return;
+
       // 保留系統 / 既有的修飾鍵快捷鍵（Cmd+L 切換佈局、Cmd+R reload 等）
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       // 避免長按重複觸發動作
       if (e.repeat) return;
 
+      // g 前綴 chord：g 後接 i → 進入分鐘輸入
+      if (pendingGRef.current) {
+        if (e.key === 'i' || e.key === 'I') {
+          e.preventDefault();
+          clearChord();
+          onEnterInput?.();
+          return;
+        }
+        // 其他鍵則取消 chord，繼續往下正常處理
+        clearChord();
+      }
+
       switch (e.key) {
+        case 'g':
+        case 'G':
+          e.preventDefault();
+          pendingGRef.current = true;
+          chordTimerRef.current = setTimeout(clearChord, CHORD_TIMEOUT);
+          break;
         case 'p':
         case 'P':
           e.preventDefault();
@@ -71,6 +115,17 @@ export const useKeyboardControls = ({
         case 'C':
           e.preventDefault();
           onDismissNotification();
+          break;
+        // + / =：計時器加 1 分
+        case '+':
+        case '=':
+          e.preventDefault();
+          onIncrement?.();
+          break;
+        // -：計時器減 1 分
+        case '-':
+          e.preventDefault();
+          onDecrement?.();
           break;
         case 'Escape':
           onCancel();
@@ -102,7 +157,10 @@ export const useKeyboardControls = ({
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      clearChord();
+    };
   }, [
     onTogglePlay,
     onRequestReset,
@@ -111,5 +169,8 @@ export const useKeyboardControls = ({
     onCancel,
     onDismissNotification,
     focusRefs,
+    onIncrement,
+    onDecrement,
+    onEnterInput,
   ]);
 };

--- a/src/renderer/hooks/useKeyboardControls.ts
+++ b/src/renderer/hooks/useKeyboardControls.ts
@@ -23,19 +23,14 @@ const CHORD_TIMEOUT = 500;
  * 焦點在 app 視窗內時生效；保留帶修飾鍵的快捷鍵（如 Cmd+L 切換佈局）。
  * Enter / Space 啟動目前 focus 的按鈕，沿用原生 button 行為，這裡不攔截。
  * 計時器模式額外支援 + / − 調整分鐘、gi 進入直接輸入。
+ *
+ * options 以 ref 保存，listener 只在 mount 註冊一次（deps []），
+ * 避免每 render 重新訂閱而把進行中的 gi chord 清掉。
  */
-export const useKeyboardControls = ({
-  onTogglePlay,
-  onRequestReset,
-  onSkipNext,
-  onToggleDark,
-  onCancel,
-  onDismissNotification,
-  focusRefs,
-  onIncrement,
-  onDecrement,
-  onEnterInput,
-}: KeyboardControlsOptions) => {
+export const useKeyboardControls = (options: KeyboardControlsOptions) => {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
   // 記住「g」是否在等待後續鍵（chord），與其逾時計時器
   const pendingGRef = useRef(false);
   const chordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -50,7 +45,7 @@ export const useKeyboardControls = ({
     };
 
     const moveFocus = (dir: 1 | -1) => {
-      const els = focusRefs
+      const els = optionsRef.current.focusRefs
         .map((ref) => ref.current)
         .filter((el): el is HTMLElement => el !== null);
       if (els.length === 0) return;
@@ -71,7 +66,19 @@ export const useKeyboardControls = ({
       // 避免長按重複觸發動作
       if (e.repeat) return;
 
-      // g 前綴 chord：g 後接 i → 進入分鐘輸入
+      const {
+        onTogglePlay,
+        onRequestReset,
+        onSkipNext,
+        onToggleDark,
+        onCancel,
+        onDismissNotification,
+        onIncrement,
+        onDecrement,
+        onEnterInput,
+      } = optionsRef.current;
+
+      // g 前綴 chord：g 後接 i → 進入分鐘輸入（僅在有 onEnterInput 時生效）
       if (pendingGRef.current) {
         if (e.key === 'i' || e.key === 'I') {
           e.preventDefault();
@@ -86,6 +93,8 @@ export const useKeyboardControls = ({
       switch (e.key) {
         case 'g':
         case 'G':
+          // 無對應功能時不攔截、也不起 chord
+          if (!onEnterInput) break;
           e.preventDefault();
           pendingGRef.current = true;
           chordTimerRef.current = setTimeout(clearChord, CHORD_TIMEOUT);
@@ -116,16 +125,18 @@ export const useKeyboardControls = ({
           e.preventDefault();
           onDismissNotification();
           break;
-        // + / =：計時器加 1 分
+        // + / =：計時器加 1 分（無 handler 時不攔截）
         case '+':
         case '=':
+          if (!onIncrement) break;
           e.preventDefault();
-          onIncrement?.();
+          onIncrement();
           break;
-        // -：計時器減 1 分
+        // -：計時器減 1 分（無 handler 時不攔截）
         case '-':
+          if (!onDecrement) break;
           e.preventDefault();
-          onDecrement?.();
+          onDecrement();
           break;
         case 'Escape':
           onCancel();
@@ -161,16 +172,5 @@ export const useKeyboardControls = ({
       window.removeEventListener('keydown', handleKeyDown);
       clearChord();
     };
-  }, [
-    onTogglePlay,
-    onRequestReset,
-    onSkipNext,
-    onToggleDark,
-    onCancel,
-    onDismissNotification,
-    focusRefs,
-    onIncrement,
-    onDecrement,
-    onEnterInput,
-  ]);
+  }, []);
 };

--- a/src/renderer/hooks/usePomodoro.ts
+++ b/src/renderer/hooks/usePomodoro.ts
@@ -62,15 +62,7 @@ export const usePomodoro = (
     }
   }, [state.timeLeft, state, settings]);
 
-  useEffect(() => {
-    if (state.timeLeft === 0 && !state.isRunning) {
-      const message = state.mode === 'focus' ? '該休息一下嘍！' : '繼續努力～';
-
-      setTimeout(() => {
-        window.electronAPI.sendNotification('卡皮巴拉番茄鐘', message);
-      }, 100);
-    }
-  }, [state.timeLeft, state.isRunning, state.mode]);
+  // 番茄鐘倒數結束通知由 App.tsx 的 effect 送出（此處不再重複，避免雙發）。
 
   return {
     state,

--- a/src/renderer/hooks/usePomodoro.ts
+++ b/src/renderer/hooks/usePomodoro.ts
@@ -1,11 +1,15 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { PomodoroState, PomodoroSettings } from '../types/pomodoro';
 import { getPomodoroSettings } from '../config/pomodoro.config';
 import { useCountdownTick } from './useCountdownTick';
 
 const DEFAULT_SETTINGS: PomodoroSettings = getPomodoroSettings();
 
-export const usePomodoro = (settings: PomodoroSettings = DEFAULT_SETTINGS) => {
+// onPomodoroComplete：每完成一次 focus 時呼叫（用於累加共用 streak）
+export const usePomodoro = (
+  settings: PomodoroSettings = DEFAULT_SETTINGS,
+  onPomodoroComplete?: () => void,
+) => {
   const [state, setState] = useState<PomodoroState>({
     mode: 'focus',
     timeLeft: settings.focusTime,
@@ -32,6 +36,9 @@ export const usePomodoro = (settings: PomodoroSettings = DEFAULT_SETTINGS) => {
     }));
   }, [settings.focusTime]);
 
+  const onCompleteRef = useRef(onPomodoroComplete);
+  onCompleteRef.current = onPomodoroComplete;
+
   // 手動跳到下一階段（focus <-> break），重用 getNextState
   const skipToNext = useCallback(() => {
     setState((prev) => getNextState(prev, settings));
@@ -46,6 +53,10 @@ export const usePomodoro = (settings: PomodoroSettings = DEFAULT_SETTINGS) => {
 
   useEffect(() => {
     if (state.timeLeft === 0) {
+      // 完成一次 focus → 累加共用 streak（+1，等同 25 分鐘）
+      if (state.mode === 'focus') {
+        onCompleteRef.current?.();
+      }
       const nextState = getNextState(state, settings);
       setState(nextState);
     }

--- a/src/renderer/hooks/usePomodoro.ts
+++ b/src/renderer/hooks/usePomodoro.ts
@@ -1,10 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
-import {
-  PomodoroMode,
-  PomodoroState,
-  PomodoroSettings,
-} from '../types/pomodoro';
+import { PomodoroState, PomodoroSettings } from '../types/pomodoro';
 import { getPomodoroSettings } from '../config/pomodoro.config';
+import { useCountdownTick } from './useCountdownTick';
 
 const DEFAULT_SETTINGS: PomodoroSettings = getPomodoroSettings();
 
@@ -40,38 +37,12 @@ export const usePomodoro = (settings: PomodoroSettings = DEFAULT_SETTINGS) => {
     setState((prev) => getNextState(prev, settings));
   }, [settings]);
 
-  useEffect(() => {
-    let animationFrameId: number;
-    let lastTime = Date.now();
-
-    const updateTimer = () => {
-      if (state.isRunning && state.timeLeft > 0) {
-        const currentTime = Date.now();
-        const deltaTime = Math.floor((currentTime - lastTime) / 1000);
-
-        if (deltaTime >= 1) {
-          setState((prev) => ({
-            ...prev,
-            timeLeft: Math.max(0, prev.timeLeft - deltaTime),
-          }));
-          lastTime = currentTime;
-        }
-
-        animationFrameId = requestAnimationFrame(updateTimer);
-      }
-    };
-
-    if (state.isRunning) {
-      lastTime = Date.now();
-      animationFrameId = requestAnimationFrame(updateTimer);
-    }
-
-    return () => {
-      if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId);
-      }
-    };
-  }, [state.isRunning, state.timeLeft]);
+  useCountdownTick(state.isRunning, (deltaSeconds) => {
+    setState((prev) => ({
+      ...prev,
+      timeLeft: Math.max(0, prev.timeLeft - deltaSeconds),
+    }));
+  });
 
   useEffect(() => {
     if (state.timeLeft === 0) {

--- a/src/renderer/hooks/usePomodoro.ts
+++ b/src/renderer/hooks/usePomodoro.ts
@@ -44,7 +44,7 @@ export const usePomodoro = (
     setState((prev) => getNextState(prev, settings));
   }, [settings]);
 
-  useCountdownTick(state.isRunning, (deltaSeconds) => {
+  useCountdownTick(state.isRunning, state.timeLeft, (deltaSeconds) => {
     setState((prev) => ({
       ...prev,
       timeLeft: Math.max(0, prev.timeLeft - deltaSeconds),

--- a/src/renderer/hooks/useStreak.ts
+++ b/src/renderer/hooks/useStreak.ts
@@ -1,0 +1,30 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const STREAK_STORAGE_KEY = 'capybara-streak';
+
+// 小數 2 位（番茄鐘每完成 +1；計時器 +分鐘/25）
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+const loadStreak = (): number => {
+  const raw = localStorage.getItem(STREAK_STORAGE_KEY);
+  const parsed = raw ? parseFloat(raw) : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * 番茄鐘與計時器共用的累積 streak（localStorage 持久化）。
+ * 單位一致：25 分鐘 = 1.00，故番茄鐘完成 +1、計時器 +分鐘/25。
+ */
+export const useStreak = () => {
+  const [streak, setStreak] = useState<number>(loadStreak);
+
+  const addStreak = useCallback((amount: number) => {
+    setStreak((prev) => round2(prev + amount));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STREAK_STORAGE_KEY, String(streak));
+  }, [streak]);
+
+  return { streak, addStreak };
+};

--- a/src/renderer/hooks/useStreak.ts
+++ b/src/renderer/hooks/useStreak.ts
@@ -1,9 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
+import { addStreak as addStreakValue } from '../utils/streak';
 
 const STREAK_STORAGE_KEY = 'capybara-streak';
-
-// 小數 2 位（番茄鐘每完成 +1；計時器 +分鐘/25）
-const round2 = (n: number): number => Math.round(n * 100) / 100;
 
 const loadStreak = (): number => {
   const raw = localStorage.getItem(STREAK_STORAGE_KEY);
@@ -19,7 +17,7 @@ export const useStreak = () => {
   const [streak, setStreak] = useState<number>(loadStreak);
 
   const addStreak = useCallback((amount: number) => {
-    setStreak((prev) => round2(prev + amount));
+    setStreak((prev) => addStreakValue(prev, amount));
   }, []);
 
   useEffect(() => {

--- a/src/renderer/hooks/useTimer.ts
+++ b/src/renderer/hooks/useTimer.ts
@@ -1,16 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { TimerState } from '../types/timer';
 import { useCountdownTick } from './useCountdownTick';
+import { minutesToStreak, clampMinutes } from '../utils/streak';
 
 export const MIN_MINUTES = 1;
 export const MAX_MINUTES = 9999; // 最多 4 位數
 export const DEFAULT_MINUTES = 25;
-
-const clampMinutes = (n: number): number =>
-  Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.floor(n)));
-
-// 小數 2 位（issue #9：分鐘 / 25 累加進 streak）
-const round2 = (n: number): number => Math.round(n * 100) / 100;
 
 // onFinish：倒數歸零時回報本次獲得的 streak（分鐘 / 25），由 useStreak 統一累加
 export const useTimer = (onFinish?: (gained: number) => void) => {
@@ -46,7 +41,7 @@ export const useTimer = (onFinish?: (gained: number) => void) => {
   const setMinutes = useCallback((value: number) => {
     setState((prev) => {
       if (prev.hasStarted) return prev;
-      const minutes = clampMinutes(value);
+      const minutes = clampMinutes(value, MIN_MINUTES, MAX_MINUTES);
       return { ...prev, minutes, timeLeft: minutes * 60 };
     });
   }, []);
@@ -69,7 +64,7 @@ export const useTimer = (onFinish?: (gained: number) => void) => {
   // 倒數結束：回報 streak（交給 useStreak 累加）、回到設定狀態、發系統通知（不進下一階段）
   useEffect(() => {
     if (state.timeLeft === 0 && state.isRunning) {
-      const gained = round2(state.minutes / 25);
+      const gained = minutesToStreak(state.minutes);
 
       setState((prev) => ({
         ...prev,

--- a/src/renderer/hooks/useTimer.ts
+++ b/src/renderer/hooks/useTimer.ts
@@ -1,0 +1,110 @@
+import { useState, useCallback, useEffect } from 'react';
+import { TimerState } from '../types/timer';
+import { useCountdownTick } from './useCountdownTick';
+
+export const MIN_MINUTES = 1;
+export const MAX_MINUTES = 9999; // 最多 4 位數
+export const DEFAULT_MINUTES = 25;
+
+const STREAK_STORAGE_KEY = 'capybara-streak';
+
+const clampMinutes = (n: number): number =>
+  Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.floor(n)));
+
+// 小數 2 位（issue #9：分鐘 / 25 累加進 streak）
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+const loadStreak = (): number => {
+  const raw = localStorage.getItem(STREAK_STORAGE_KEY);
+  const parsed = raw ? parseFloat(raw) : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const useTimer = () => {
+  const [state, setState] = useState<TimerState>(() => ({
+    minutes: DEFAULT_MINUTES,
+    timeLeft: DEFAULT_MINUTES * 60,
+    isRunning: false,
+    hasStarted: false,
+    streak: loadStreak(),
+  }));
+
+  const startTimer = useCallback(() => {
+    setState((prev) => ({ ...prev, isRunning: true, hasStarted: true }));
+  }, []);
+
+  const pauseTimer = useCallback(() => {
+    setState((prev) => ({ ...prev, isRunning: false }));
+  }, []);
+
+  // 重置：停止並回到設定狀態，時間還原為目前已設分鐘
+  const resetTimer = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isRunning: false,
+      hasStarted: false,
+      timeLeft: prev.minutes * 60,
+    }));
+  }, []);
+
+  // 設定分鐘（+/− 與 gi 直接輸入共用）；僅在未開始時可調整
+  const setMinutes = useCallback((value: number) => {
+    setState((prev) => {
+      if (prev.hasStarted) return prev;
+      const minutes = clampMinutes(value);
+      return { ...prev, minutes, timeLeft: minutes * 60 };
+    });
+  }, []);
+
+  const increment = useCallback(() => {
+    setMinutes(state.minutes + 1);
+  }, [setMinutes, state.minutes]);
+
+  const decrement = useCallback(() => {
+    setMinutes(state.minutes - 1);
+  }, [setMinutes, state.minutes]);
+
+  useCountdownTick(state.isRunning, (deltaSeconds) => {
+    setState((prev) => ({
+      ...prev,
+      timeLeft: Math.max(0, prev.timeLeft - deltaSeconds),
+    }));
+  });
+
+  // 倒數結束：累加 streak、回到設定狀態、發系統通知（不進下一階段）
+  useEffect(() => {
+    if (state.timeLeft === 0 && state.isRunning) {
+      const gained = round2(state.minutes / 25);
+
+      setState((prev) => ({
+        ...prev,
+        isRunning: false,
+        hasStarted: false,
+        timeLeft: prev.minutes * 60,
+        streak: round2(prev.streak + gained),
+      }));
+
+      setTimeout(() => {
+        window.electronAPI.sendNotification(
+          '卡皮巴拉計時器',
+          `時間到！streak +${gained.toFixed(2)}`,
+        );
+      }, 100);
+    }
+  }, [state.timeLeft, state.isRunning, state.minutes]);
+
+  // 持久化 streak
+  useEffect(() => {
+    localStorage.setItem(STREAK_STORAGE_KEY, String(state.streak));
+  }, [state.streak]);
+
+  return {
+    state,
+    startTimer,
+    pauseTimer,
+    resetTimer,
+    increment,
+    decrement,
+    setMinutes,
+  };
+};

--- a/src/renderer/hooks/useTimer.ts
+++ b/src/renderer/hooks/useTimer.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { TimerState } from '../types/timer';
 import { useCountdownTick } from './useCountdownTick';
 
@@ -6,28 +6,23 @@ export const MIN_MINUTES = 1;
 export const MAX_MINUTES = 9999; // 最多 4 位數
 export const DEFAULT_MINUTES = 25;
 
-const STREAK_STORAGE_KEY = 'capybara-streak';
-
 const clampMinutes = (n: number): number =>
   Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.floor(n)));
 
 // 小數 2 位（issue #9：分鐘 / 25 累加進 streak）
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 
-const loadStreak = (): number => {
-  const raw = localStorage.getItem(STREAK_STORAGE_KEY);
-  const parsed = raw ? parseFloat(raw) : 0;
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
-export const useTimer = () => {
+// onFinish：倒數歸零時回報本次獲得的 streak（分鐘 / 25），由 useStreak 統一累加
+export const useTimer = (onFinish?: (gained: number) => void) => {
   const [state, setState] = useState<TimerState>(() => ({
     minutes: DEFAULT_MINUTES,
     timeLeft: DEFAULT_MINUTES * 60,
     isRunning: false,
     hasStarted: false,
-    streak: loadStreak(),
   }));
+
+  const onFinishRef = useRef(onFinish);
+  onFinishRef.current = onFinish;
 
   const startTimer = useCallback(() => {
     setState((prev) => ({ ...prev, isRunning: true, hasStarted: true }));
@@ -71,7 +66,7 @@ export const useTimer = () => {
     }));
   });
 
-  // 倒數結束：累加 streak、回到設定狀態、發系統通知（不進下一階段）
+  // 倒數結束：回報 streak（交給 useStreak 累加）、回到設定狀態、發系統通知（不進下一階段）
   useEffect(() => {
     if (state.timeLeft === 0 && state.isRunning) {
       const gained = round2(state.minutes / 25);
@@ -81,8 +76,9 @@ export const useTimer = () => {
         isRunning: false,
         hasStarted: false,
         timeLeft: prev.minutes * 60,
-        streak: round2(prev.streak + gained),
       }));
+
+      onFinishRef.current?.(gained);
 
       setTimeout(() => {
         window.electronAPI.sendNotification(
@@ -92,11 +88,6 @@ export const useTimer = () => {
       }, 100);
     }
   }, [state.timeLeft, state.isRunning, state.minutes]);
-
-  // 持久化 streak
-  useEffect(() => {
-    localStorage.setItem(STREAK_STORAGE_KEY, String(state.streak));
-  }, [state.streak]);
 
   return {
     state,

--- a/src/renderer/hooks/useTimer.ts
+++ b/src/renderer/hooks/useTimer.ts
@@ -46,15 +46,23 @@ export const useTimer = (onFinish?: (gained: number) => void) => {
     });
   }, []);
 
-  const increment = useCallback(() => {
-    setMinutes(state.minutes + 1);
-  }, [setMinutes, state.minutes]);
+  // 以函式式更新計算，避免落在同一批次時用到 stale 的 minutes
+  const adjustMinutes = useCallback((delta: number) => {
+    setState((prev) => {
+      if (prev.hasStarted) return prev;
+      const minutes = clampMinutes(
+        prev.minutes + delta,
+        MIN_MINUTES,
+        MAX_MINUTES,
+      );
+      return { ...prev, minutes, timeLeft: minutes * 60 };
+    });
+  }, []);
 
-  const decrement = useCallback(() => {
-    setMinutes(state.minutes - 1);
-  }, [setMinutes, state.minutes]);
+  const increment = useCallback(() => adjustMinutes(1), [adjustMinutes]);
+  const decrement = useCallback(() => adjustMinutes(-1), [adjustMinutes]);
 
-  useCountdownTick(state.isRunning, (deltaSeconds) => {
+  useCountdownTick(state.isRunning, state.timeLeft, (deltaSeconds) => {
     setState((prev) => ({
       ...prev,
       timeLeft: Math.max(0, prev.timeLeft - deltaSeconds),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,7 +7,8 @@
       body {
         margin: 0;
         overflow: hidden;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
           Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       }
       #root {

--- a/src/renderer/themes/colors.ts
+++ b/src/renderer/themes/colors.ts
@@ -1,10 +1,10 @@
 import type { Theme } from '@emotion/react';
-import { PomodoroMode } from '../types/pomodoro';
+import { AccentKey } from '../types/timer';
 
 /**
  * 各模式強調色（計時數字 + 按鈕）。
- * 依使用者決定「亮色跟暗色一樣」，明暗共用同一組強調色，
- * 只有底色 / surface / 文字色會隨明暗不同。
+ * 番茄鐘三模式明暗共用同一組強調色；計時器模式（timer）的暖琥珀色在亮色時略加深以保對比，
+ * 故 timer 另外分亮/暗兩組，由 buildTheme 依 isDark 取用。
  */
 interface ModeAccent {
   accent: string;
@@ -12,7 +12,7 @@ interface ModeAccent {
   buttonText: string;
 }
 
-const MODE_ACCENTS: Record<PomodoroMode, ModeAccent> = {
+const MODE_ACCENTS: Record<AccentKey, ModeAccent> = {
   focus: { accent: '#e26a6a', accentHover: '#ec8585', buttonText: '#1a0c0c' },
   shortBreak: {
     accent: '#5fc28a',
@@ -24,6 +24,15 @@ const MODE_ACCENTS: Record<PomodoroMode, ModeAccent> = {
     accentHover: '#5fb4ef',
     buttonText: '#0b1320',
   },
+  // 暗色版琥珀；亮色版見 TIMER_ACCENT_LIGHT
+  timer: { accent: '#e0a44a', accentHover: '#eab866', buttonText: '#1f1404' },
+};
+
+// 計時器亮色版：底色為白時，琥珀需加深才有足夠對比
+const TIMER_ACCENT_LIGHT: ModeAccent = {
+  accent: '#d6912f',
+  accentHover: '#c07f22',
+  buttonText: '#ffffff',
 };
 
 interface BasePalette {
@@ -49,9 +58,10 @@ const darkBase: BasePalette = {
  * 依「是否暗色」與「目前模式」組出 Emotion Theme。
  * 在 App.tsx 以 useMemo(buildTheme(isDark, state.mode)) 計算。
  */
-export const buildTheme = (isDark: boolean, mode: PomodoroMode): Theme => {
+export const buildTheme = (isDark: boolean, mode: AccentKey): Theme => {
   const base = isDark ? darkBase : lightBase;
-  const modeAccent = MODE_ACCENTS[mode];
+  const modeAccent =
+    mode === 'timer' && !isDark ? TIMER_ACCENT_LIGHT : MODE_ACCENTS[mode];
 
   return {
     isDark,

--- a/src/renderer/themes/layouts.ts
+++ b/src/renderer/themes/layouts.ts
@@ -2,44 +2,44 @@ export const layouts = {
   portrait: {
     window: {
       width: 400,
-      height: 800
+      height: 800,
     },
     styles: {
       container: {
         maxWidth: '400px',
         minHeight: '100vh',
         padding: '2rem 1rem',
-        gap: '1.5rem'
+        gap: '1.5rem',
       },
       title: {
         fontSize: '2.5rem',
-        marginBottom: '2rem'
+        marginBottom: '2rem',
       },
       image: {
         width: '150px',
         height: '150px',
-        margin: '1rem auto'
-      }
-    }
+        margin: '1rem auto',
+      },
+    },
   },
   landscape: {
     window: {
       width: 800,
-      height: 600
+      height: 600,
     },
     styles: {
       container: {
         maxWidth: '800px',
-        minHeight: '600px'
+        minHeight: '600px',
       },
       title: {
         fontSize: '2.2rem',
-        marginBottom: '1.5rem'
+        marginBottom: '1.5rem',
       },
       image: {
         width: '120px',
-        height: '120px'
-      }
-    }
-  }
-}; 
+        height: '120px',
+      },
+    },
+  },
+};

--- a/src/renderer/types/electron-localshortcut.d.ts
+++ b/src/renderer/types/electron-localshortcut.d.ts
@@ -1,6 +1,10 @@
 declare module 'electron-localshortcut' {
   import { BrowserWindow } from 'electron';
-  
-  export function register(win: BrowserWindow, accelerator: string, callback: () => void): void;
+
+  export function register(
+    win: BrowserWindow,
+    accelerator: string,
+    callback: () => void,
+  ): void;
   export function unregisterAll(win: BrowserWindow): void;
-} 
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -3,6 +3,7 @@ export interface ElectronAPI {
   sendNotification: (title: string, body: string) => void;
   dismissNotification: () => void;
   onToggleLayout: (callback: () => void) => void;
+  onToggleMode: (callback: () => void) => void;
 }
 
 declare global {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -2,8 +2,8 @@ export interface ElectronAPI {
   getVersion: () => string;
   sendNotification: (title: string, body: string) => void;
   dismissNotification: () => void;
-  onToggleLayout: (callback: () => void) => void;
-  onToggleMode: (callback: () => void) => void;
+  onToggleLayout: (callback: () => void) => () => void;
+  onToggleMode: (callback: () => void) => () => void;
 }
 
 declare global {

--- a/src/renderer/types/timer.d.ts
+++ b/src/renderer/types/timer.d.ts
@@ -11,5 +11,4 @@ export interface TimerState {
   timeLeft: number; // 剩餘秒數
   isRunning: boolean; // 是否倒數中
   hasStarted: boolean; // 是否已開始（false = 設定狀態，顯示步進器）
-  streak: number; // 累積 streak（分鐘/25，小數 2 位）
 }

--- a/src/renderer/types/timer.d.ts
+++ b/src/renderer/types/timer.d.ts
@@ -1,0 +1,15 @@
+import { PomodoroMode } from './pomodoro';
+
+/**
+ * 強調色 key：番茄鐘三模式之外，再加上計時器模式（暖琥珀色）。
+ * 供 buildTheme 與 App 計算當前強調色用。
+ */
+export type AccentKey = PomodoroMode | 'timer';
+
+export interface TimerState {
+  minutes: number; // 使用者設定的分鐘數（1–9999）
+  timeLeft: number; // 剩餘秒數
+  isRunning: boolean; // 是否倒數中
+  hasStarted: boolean; // 是否已開始（false = 設定狀態，顯示步進器）
+  streak: number; // 累積 streak（分鐘/25，小數 2 位）
+}

--- a/src/renderer/utils/streak.test.ts
+++ b/src/renderer/utils/streak.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  round2,
+  minutesToStreak,
+  addStreak,
+  clampMinutes,
+  MINUTES_PER_STREAK,
+} from './streak';
+
+describe('minutesToStreak', () => {
+  it('整數倍數', () => {
+    expect(minutesToStreak(25)).toBe(1);
+    expect(minutesToStreak(50)).toBe(2);
+    expect(minutesToStreak(0)).toBe(0);
+  });
+
+  it('小數結果取 2 位', () => {
+    expect(minutesToStreak(12.5)).toBe(0.5);
+    expect(minutesToStreak(10)).toBe(0.4);
+    expect(minutesToStreak(1)).toBe(0.04);
+    expect(minutesToStreak(33)).toBe(1.32);
+  });
+
+  it('需要四捨五入的值', () => {
+    // 7/25 = 0.28；13/25 = 0.52
+    expect(minutesToStreak(7)).toBe(0.28);
+    expect(minutesToStreak(13)).toBe(0.52);
+    // 1分以 25 基準 = 0.04，3 分 = 0.12
+    expect(minutesToStreak(3)).toBe(0.12);
+  });
+
+  it('基準常數為 25', () => {
+    expect(MINUTES_PER_STREAK).toBe(25);
+  });
+});
+
+describe('round2', () => {
+  it('一般四捨五入', () => {
+    expect(round2(0.004)).toBe(0);
+    expect(round2(0.005)).toBe(0.01);
+    expect(round2(1.234)).toBe(1.23);
+    expect(round2(1.235)).toBe(1.24);
+  });
+
+  it('浮點誤差來源', () => {
+    expect(round2(0.1 + 0.2)).toBe(0.3);
+  });
+
+  it('已知浮點邊界：1.005 因 *100 變 100.4999… 故進位失準回 1', () => {
+    // 記錄真實行為（非理想 1.01），提醒勿用本函式做金額等精算
+    expect(round2(1.005)).toBe(1);
+  });
+
+  it('負數', () => {
+    expect(round2(-1.234)).toBe(-1.23);
+  });
+});
+
+describe('addStreak', () => {
+  it('一般相加', () => {
+    expect(addStreak(1, 0.5)).toBe(1.5);
+    expect(addStreak(0, 0.04)).toBe(0.04);
+  });
+
+  it('連加不漂移（0.1 累加 10 次 = 1）', () => {
+    let s = 0;
+    for (let i = 0; i < 10; i += 1) s = addStreak(s, 0.1);
+    expect(s).toBe(1);
+  });
+
+  it('累加計時器多段', () => {
+    // 12.5 分 (0.5) + 12.5 分 (0.5) + 25 分 (1) = 2
+    let s = 0;
+    s = addStreak(s, minutesToStreak(12.5));
+    s = addStreak(s, minutesToStreak(12.5));
+    s = addStreak(s, minutesToStreak(25));
+    expect(s).toBe(2);
+  });
+});
+
+describe('clampMinutes', () => {
+  it('夾在範圍內', () => {
+    expect(clampMinutes(25, 1, 9999)).toBe(25);
+  });
+
+  it('低於 min', () => {
+    expect(clampMinutes(0, 1, 9999)).toBe(1);
+    expect(clampMinutes(-5, 1, 9999)).toBe(1);
+  });
+
+  it('高於 max', () => {
+    expect(clampMinutes(10000, 1, 9999)).toBe(9999);
+  });
+
+  it('小數向下取整', () => {
+    expect(clampMinutes(25.9, 1, 9999)).toBe(25);
+    expect(clampMinutes(1.9, 1, 9999)).toBe(1);
+  });
+});

--- a/src/renderer/utils/streak.ts
+++ b/src/renderer/utils/streak.ts
@@ -1,0 +1,19 @@
+// streak 計算純函式（與 React 無關，方便單元測試）
+// 單位基準：MINUTES_PER_STREAK 分鐘 = 1.00 streak（番茄完成 +1、計時 +分鐘/25）
+
+export const MINUTES_PER_STREAK = 25;
+
+/** 四捨五入到小數 2 位 */
+export const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/** 由分鐘換算 streak 獲得量（小數 2 位） */
+export const minutesToStreak = (minutes: number): number =>
+  round2(minutes / MINUTES_PER_STREAK);
+
+/** 累加 streak，並 round2 以避免浮點漂移 */
+export const addStreak = (prev: number, gain: number): number =>
+  round2(prev + gain);
+
+/** 將分鐘夾到 [min, max] 並取整（向下） */
+export const clampMinutes = (n: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, Math.floor(n)));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "lib": ["DOM", "ES2015"],
     "typeRoots": ["./src/renderer/types", "./node_modules/@types"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
 }
-

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -7,37 +7,39 @@ module.exports = {
   entry: './src/renderer/index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist/renderer'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   resolve: {
-    extensions: ['.ts', '.tsx', '.js']
+    extensions: ['.ts', '.tsx', '.js'],
   },
   module: {
     rules: [
       {
         test: /\.tsx?$/,
         use: 'ts-loader',
-        exclude: /node_modules/
+        exclude: /node_modules/,
       },
       {
         test: /\.(png|jpg|gif|svg)$/,
-        type: 'asset/resource'
-      }
-    ]
+        type: 'asset/resource',
+      },
+    ],
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
+      'process.env.NODE_ENV': JSON.stringify(
+        process.env.NODE_ENV || 'development',
+      ),
     }),
     new CopyPlugin({
       patterns: [
-        { 
+        {
           from: 'src/renderer/index.html',
-          to: path.resolve(__dirname, 'dist/renderer') 
+          to: path.resolve(__dirname, 'dist/renderer'),
         },
-        { 
-          from: 'public', 
-          to: path.resolve(__dirname, 'dist/renderer') 
+        {
+          from: 'public',
+          to: path.resolve(__dirname, 'dist/renderer'),
         },
       ],
     }),


### PR DESCRIPTION
Closes #9

## 摘要
新增純倒數計時器模式（有別於番茄鐘循環），只支援分鐘，用 +/− 與 gi 直接輸入設定時間。

## 內容
- **useTimer / useCountdownTick**：分鐘倒數；抽出共用倒數邏輯，消除 usePomodoro 既有重複
- **設定互動**：+/−（±1 分，1–9999）、`gi` 進入直接輸入（最多 4 位，Enter 套用 / Esc 取消）
- **模式切換**：Cmd+T 與右上角切換鈕，計時器套暖琥珀強調色
- **streak（依 #9 原案）**：結束時累加 `分鐘 / 25`（小數 2 位），localStorage 持久化
- **通知**：時間到發系統通知，沿用 c / Esc 關閉機制；不自動進下一階段
- **設計稿**：docs/timer-mode-preview.html

## 驗證
- `npx tsc --noEmit`、`pnpm build` 通過
- GUI 互動（切換 / +/− / gi / 倒數到 0 通知與 streak）需手動確認

## 備註
- 計時器圖片暫沿用 capybara-focus.png
- eslint.config.mjs 為舊 eslintrc 格式、與 ESLint 9 flat config 不相容（既有問題，本 PR 未動）